### PR TITLE
Add research progress log and fix Vercel timeout

### DIFF
--- a/web/src/app/api/fast/route.ts
+++ b/web/src/app/api/fast/route.ts
@@ -5,6 +5,7 @@ import { anthropic } from "@/lib/anthropic";
 import { buildFastCheckPrompt } from "@/lib/prompts";
 
 export const runtime = "nodejs";
+export const maxDuration = 300;
 
 const FastCheckSchema = z.object({
   idea: z

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -86,7 +86,8 @@ export type StreamEvent =
   | { type: "phase_change"; phase: DiscoveryPhase }
   | { type: "scores"; scores: ConfidenceScores }
   | { type: "kill_signal"; signal: KillSignal }
-  | { type: "searching"; active: boolean } // pause_turn indicator
+  | { type: "searching"; active: boolean }
+  | { type: "search_query"; query: string } // emitted when a web search query is ready to run
   | { type: "done" }
   | { type: "error"; message: string };
 


### PR DESCRIPTION
## Summary

- **Research progress log**: extracts actual web search queries from Anthropic `input_json_delta` stream events and emits `search_query` events. `SearchingIndicator` redesigned to show a Claude-style running list — completed searches get a ✓, in-progress shows pulsing dots with the query text.
- **Vercel timeout fix**: adds `maxDuration = 300` to `/api/chat` and `/api/fast` — research phase with 5 web searches was hitting Vercel's default function duration limit.
- **New `StreamEvent` type**: added `search_query` variant.

## Test plan
- [ ] Start a Full Validation and reach the research phase
- [ ] Confirm search queries appear one by one with pulsing indicator
- [ ] Confirm completed searches show ✓ checkmark
- [ ] Confirm research completes without timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)