### PR TITLE
Fix tool markup, font loading, text formatting, and download filename

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Inter:wght@400;500;600&display=swap');
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
@@ -71,8 +70,8 @@
     --border-focus:   #e05a2b;
 
     /* ── Typography ── */
-    --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, 'Courier New', monospace;
-    --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+    --font-mono: var(--font-jetbrains-mono), 'Fira Code', 'Cascadia Code', ui-monospace, 'Courier New', monospace;
+    --font-sans: var(--font-inter), system-ui, -apple-system, sans-serif;
 
     /* Type scale */
     --text-xs:   0.75rem;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,20 @@
 import type { Metadata } from "next";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "ProveIt — Validate your product idea before you build",
@@ -13,7 +28,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <body className="min-h-screen">{children}</body>
     </html>
   );

--- a/web/src/components/validate/DownloadButton.tsx
+++ b/web/src/components/validate/DownloadButton.tsx
@@ -15,7 +15,7 @@ export default function DownloadButton({ session }: DownloadButtonProps) {
     setIsGenerating(true);
     try {
       const markdown = generateDiscoveryMarkdown(session);
-      const blob = new Blob([markdown], { type: "text/markdown" });
+      const blob = new Blob([markdown], { type: "text/plain;charset=utf-8" });
       const url = URL.createObjectURL(blob);
 
       const date = new Date().toISOString().split("T")[0];
@@ -34,7 +34,8 @@ export default function DownloadButton({ session }: DownloadButtonProps) {
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      // Defer revoke so the browser has time to initiate the download
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
     } catch {
       // Could show a toast here — keeping simple for MVP
     } finally {

--- a/web/src/components/validate/StreamingText.tsx
+++ b/web/src/components/validate/StreamingText.tsx
@@ -15,6 +15,11 @@ export default function StreamingText({ text, isStreaming }: StreamingTextProps)
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          // Downsize headings for chat context — the model uses ## for sections
+          // but full h2 is too large inside a message bubble.
+          h1: ({ children }) => <p className="font-bold">{children}</p>,
+          h2: ({ children }) => <p className="font-bold">{children}</p>,
+          h3: ({ children }) => <p className="font-semibold">{children}</p>,
           a: ({ href, children }) => (
             <a
               href={href}

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -10,13 +10,18 @@ const KILL_SIGNAL_LABEL: Record<string, string> = {
 };
 
 /**
- * Strips <tool_call> and <tool_response> markup that the model sometimes
- * includes literally in its text output alongside actual API tool calls.
+ * Strips tool markup that the model sometimes includes literally in its text
+ * output alongside actual API tool calls. Handles both formats:
+ * - <tool_call>/<tool_response> (older format)
+ * - <function_calls>/<function_response>/<invoke> (newer format)
  */
 export function cleanAssistantText(text: string): string {
   return text
     .replace(/<tool_call>[\s\S]*?<\/tool_call>/g, "")
     .replace(/<tool_response>[\s\S]*?<\/tool_response>/g, "")
+    .replace(/<function_calls>[\s\S]*?<\/function_calls>/g, "")
+    .replace(/<function_response>[\s\S]*?<\/function_response>/g, "")
+    .replace(/<invoke[\s\S]*?<\/invoke>/g, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -22,6 +22,10 @@ export function cleanAssistantText(text: string): string {
     .replace(/<function_calls>[\s\S]*?<\/function_calls>/g, "")
     .replace(/<function_response>[\s\S]*?<\/function_response>/g, "")
     .replace(/<invoke[\s\S]*?<\/invoke>/g, "")
+    // Ensure standalone --- dividers have a blank line before them.
+    // Without this, CommonMark treats them as setext heading markers that
+    // promote the preceding paragraph into an <h2>.
+    .replace(/([^\n])\n(---)\n/g, "$1\n\n$2\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/web/tests/unit/clean-assistant-text.test.ts
+++ b/web/tests/unit/clean-assistant-text.test.ts
@@ -120,4 +120,42 @@ describe("cleanAssistantText", () => {
     // After stripping, only whitespace remains — trim produces ""
     expect(cleanAssistantText(input)).toBe("");
   });
+
+  // ─── function_calls / function_response (newer format) ───────────────────────
+
+  it("strips <function_calls> block", () => {
+    const input =
+      'Before\n<function_calls>\n<invoke name="web_search"><parameter name="query">test</parameter></invoke>\n</function_calls>\nAfter';
+    const result = cleanAssistantText(input);
+    expect(result).not.toContain("<function_calls>");
+    expect(result).not.toContain("<invoke");
+    expect(result).toContain("Before");
+    expect(result).toContain("After");
+  });
+
+  it("strips <function_response> block", () => {
+    const input =
+      'Searching...\n<function_response>[{"title":"Result"}]</function_response>\nHere are my findings.';
+    const result = cleanAssistantText(input);
+    expect(result).not.toContain("<function_response>");
+    expect(result).toContain("Searching...");
+    expect(result).toContain("Here are my findings.");
+  });
+
+  it("strips interleaved function_calls and function_response blocks", () => {
+    const input =
+      'Track 1\n<function_calls><invoke name="web_search"><parameter name="query">foo</parameter></invoke></function_calls>\n<function_response>[{}]</function_response>\nTrack 2';
+    const result = cleanAssistantText(input);
+    expect(result).not.toContain("<function_calls>");
+    expect(result).not.toContain("<function_response>");
+    expect(result).not.toContain("<invoke");
+    expect(result).toContain("Track 1");
+    expect(result).toContain("Track 2");
+  });
+
+  it("returns empty string for a message that is purely function_calls markup", () => {
+    const input =
+      '<function_calls><invoke name="web_search"><parameter name="query">q</parameter></invoke></function_calls><function_response>[{}]</function_response>';
+    expect(cleanAssistantText(input)).toBe("");
+  });
 });

--- a/web/tests/unit/clean-assistant-text.test.ts
+++ b/web/tests/unit/clean-assistant-text.test.ts
@@ -121,6 +121,23 @@ describe("cleanAssistantText", () => {
     expect(cleanAssistantText(input)).toBe("");
   });
 
+  // ─── Standalone --- dividers: blank-line insertion ────────────────────────────
+
+  it("inserts blank line before standalone --- to prevent setext heading promotion", () => {
+    // Without the fix, CommonMark turns the paragraph above into an <h2>
+    const input = "Some finding\n---\nNext section";
+    const result = cleanAssistantText(input);
+    // The --- must be preceded by a blank line in the output
+    expect(result).toContain("Some finding\n\n---");
+    expect(result).toContain("Next section");
+  });
+
+  it("does not affect table separator rows (pipes + dashes)", () => {
+    const input = "| Name | Status |\n|------|--------|\n| Harvest | Active |";
+    const result = cleanAssistantText(input);
+    expect(result).toContain("|------|--------|");
+  });
+
   // ─── function_calls / function_response (newer format) ───────────────────────
 
   it("strips <function_calls> block", () => {


### PR DESCRIPTION
## Summary

- **Tool markup in chat UI** — `cleanAssistantText` now strips `<function_calls>/<function_response>/<invoke>` tags (the format the model actually outputs during research streaming) in addition to the existing `<tool_call>/<tool_response>` patterns
- **Font loading (CSP)** — Removed `@import url(fonts.googleapis.com)` from globals.css; switched to `next/font/google` which self-hosts fonts at build time, no CSP policy changes needed
- **Research findings rendering as giant headings** — The model uses `---` as section dividers but without a preceding blank line CommonMark promotes the paragraph above into an h2. Fixed in `cleanAssistantText` by inserting a blank line before standalone `---` lines. Added heading overrides in `StreamingText` so h1–h3 render as bold paragraphs (appropriate for chat context)
- **Download saved with UUID filename** — `text/markdown` MIME type caused Chrome to ignore the `download` attribute; switched to `text/plain;charset=utf-8` and deferred `revokeObjectURL` to ensure the download initiates before the URL is freed

## Test plan

- [ ] Fonts render correctly (JetBrains Mono + Inter) with no CSP errors in console
- [ ] Research phase findings render as normal-sized text with horizontal rule separators, not giant headings
- [ ] DOWNLOAD SUMMARY saves a file named `proveit-<slug>-<date>.md` (not a UUID)
- [ ] No `<function_calls>` or `<tool_call>` XML visible in chat messages
- [ ] 180 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)