### PR TITLE
feat: WoZ email-capture CTA replaces CLI pointer (#30)

### DIFF
--- a/web/src/app/api/woz-intent/route.ts
+++ b/web/src/app/api/woz-intent/route.ts
@@ -1,0 +1,74 @@
+import "server-only";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { recordWozIntent } from "@/lib/woz-intent";
+import { notifyWozIntent } from "@/lib/notifications";
+import { checkRateLimit, getClientIp, RATE_LIMITS } from "@/lib/rate-limit";
+
+export const runtime = "nodejs";
+
+const WozIntentSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .min(5, "That doesn't look like a valid email")
+    .max(254, "Email too long")
+    .email("That doesn't look like a valid email"),
+  chosenOption: z.enum(["one_off", "subscription"]),
+  intendedUse: z.string().trim().max(500).optional(),
+  ideaSummary: z.string().trim().max(500).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const { limit, windowMs } = RATE_LIMITS.fast;
+  const rl = await checkRateLimit(ip, "fast", limit, windowMs);
+  if (!rl.allowed) {
+    return new Response(
+      JSON.stringify({ error: "Too many submissions. Please wait a moment and try again." }),
+      { status: 429, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid request body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const parsed = WozIntentSchema.safeParse(body);
+  if (!parsed.success) {
+    const message = parsed.error.errors[0]?.message ?? "Invalid input";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  await recordWozIntent({
+    email: parsed.data.email,
+    chosenOption: parsed.data.chosenOption,
+    intendedUse: parsed.data.intendedUse,
+    ideaSummary: parsed.data.ideaSummary,
+    ip,
+  });
+
+  await notifyWozIntent({
+    email: parsed.data.email,
+    chosenOption: parsed.data.chosenOption,
+    intendedUse: parsed.data.intendedUse ?? "",
+    ideaSummary: parsed.data.ideaSummary ?? "",
+    ip,
+    ts: new Date().toISOString(),
+  });
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/web/src/components/validate/ChatInterface.tsx
+++ b/web/src/components/validate/ChatInterface.tsx
@@ -629,7 +629,7 @@ export default function ChatInterface() {
               <div className="flex flex-col sm:flex-row gap-[var(--space-4)]">
                 <DownloadButton session={activeSession} />
               </div>
-              <FullBundlePointer />
+              <FullBundlePointer session={activeSession} />
             </div>
           )}
         </div>

--- a/web/src/components/validate/FullBundlePointer.tsx
+++ b/web/src/components/validate/FullBundlePointer.tsx
@@ -1,25 +1,221 @@
-export default function FullBundlePointer() {
+"use client";
+
+import { useState, useCallback } from "react";
+import type { ValidationSession } from "@/types";
+
+interface FullBundlePointerProps {
+  session?: ValidationSession;
+}
+
+type ChosenOption = "one_off" | "subscription";
+
+const OPTION_LABELS: Record<ChosenOption, string> = {
+  one_off: "£4.99 (one-off)",
+  subscription: "£9.99/mo",
+};
+
+export default function FullBundlePointer({ session }: FullBundlePointerProps) {
+  const [modalOption, setModalOption] = useState<ChosenOption | null>(null);
+  const [email, setEmail] = useState("");
+  const [intendedUse, setIntendedUse] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const closeModal = useCallback(() => {
+    if (submitting) return;
+    setModalOption(null);
+    setError(null);
+    if (submitted) {
+      // Reset after a successful submission has been acknowledged.
+      setEmail("");
+      setIntendedUse("");
+      setSubmitted(false);
+    }
+  }, [submitting, submitted]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!modalOption) return;
+      setSubmitting(true);
+      setError(null);
+      try {
+        const res = await fetch("/api/woz-intent", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email,
+            chosenOption: modalOption,
+            intendedUse,
+            ideaSummary: session?.ideaSummary ?? "",
+          }),
+        });
+        if (!res.ok) {
+          const data = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(data.error ?? "Couldn't submit. Please try again.");
+        }
+        setSubmitted(true);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Couldn't submit. Please try again.");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [modalOption, email, intendedUse, session?.ideaSummary]
+  );
+
   return (
-    <p
-      className="font-sans text-xs leading-relaxed max-w-md"
-      style={{ color: "var(--text-secondary)" }}
-    >
-      Want the full handoff bundle —{" "}
-      <code className="font-mono text-[0.72rem]">discovery.md</code>,{" "}
-      <code className="font-mono text-[0.72rem]">brand.md</code>,{" "}
-      <code className="font-mono text-[0.72rem]">spec.md</code>,{" "}
-      <code className="font-mono text-[0.72rem]">design-brief.md</code>,
-      and paste-ready Claude Design prompts? Run <code className="font-mono text-[0.72rem]">/proveit</code>{" "}
-      in{" "}
-      <a
-        href="https://claude.com/claude-code"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="underline underline-offset-2"
+    <div className="flex flex-col gap-[var(--space-4)] max-w-md">
+      <div className="flex flex-col sm:flex-row gap-[var(--space-3)]">
+        <button
+          type="button"
+          onClick={() => setModalOption("one_off")}
+          className="outline-btn inline-flex items-center justify-center px-[var(--space-5)] py-[var(--space-3)] rounded-[var(--radius-md)] font-sans text-sm font-medium border"
+        >
+          Get the bundle — £4.99 (one-off)
+        </button>
+        <button
+          type="button"
+          onClick={() => setModalOption("subscription")}
+          className="outline-btn inline-flex items-center justify-center px-[var(--space-5)] py-[var(--space-3)] rounded-[var(--radius-md)] font-sans text-sm font-medium border"
+        >
+          Subscribe — £9.99/mo
+        </button>
+      </div>
+
+      <p
+        className="font-sans text-xs leading-relaxed"
+        style={{ color: "var(--text-secondary)" }}
       >
-        Claude Code
-      </a>{" "}
-      — same idea, free, full pipeline.
-    </p>
+        Prefer the free path? Run <code className="font-mono text-[0.72rem]">/proveit</code> in{" "}
+        <a
+          href="https://claude.com/claude-code"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2"
+        >
+          Claude Code
+        </a>{" "}
+        — same idea, full pipeline including{" "}
+        <code className="font-mono text-[0.72rem]">discovery.md</code>,{" "}
+        <code className="font-mono text-[0.72rem]">brand.md</code>,{" "}
+        <code className="font-mono text-[0.72rem]">spec.md</code>,{" "}
+        <code className="font-mono text-[0.72rem]">design-brief.md</code>, and paste-ready Claude
+        Design prompts.
+      </p>
+
+      {modalOption !== null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="woz-modal-title"
+          className="fixed inset-0 z-50 flex items-center justify-center p-[var(--space-4)]"
+          style={{ background: "rgba(17, 26, 36, 0.5)" }}
+          onClick={closeModal}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-md rounded-[var(--radius-lg)] p-[var(--space-6)]"
+            style={{ background: "var(--surface, #ffffff)", border: "1px solid var(--border, #e0d9cf)" }}
+          >
+            {submitted ? (
+              <div className="flex flex-col gap-[var(--space-4)]">
+                <h2
+                  id="woz-modal-title"
+                  className="font-display text-lg"
+                  style={{ color: "var(--heading, #111a24)" }}
+                >
+                  Thanks — Claire will personally email you the bundle within 4 hours.
+                </h2>
+                <p className="font-sans text-sm" style={{ color: "var(--text-secondary)" }}>
+                  Check <strong>{email}</strong> (and the spam folder, just in case).
+                </p>
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="outline-btn self-start inline-flex items-center justify-center px-[var(--space-5)] py-[var(--space-2)] rounded-[var(--radius-md)] font-sans text-sm font-medium border"
+                >
+                  Close
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="flex flex-col gap-[var(--space-4)]">
+                <h2
+                  id="woz-modal-title"
+                  className="font-display text-lg"
+                  style={{ color: "var(--heading, #111a24)" }}
+                >
+                  Bundle — {OPTION_LABELS[modalOption]}
+                </h2>
+                <p className="font-sans text-sm" style={{ color: "var(--text-secondary)" }}>
+                  Drop your email and one line on what you&apos;ll use this for. Claire personally
+                  emails the bundle within 4 hours — no automation, no card capture.
+                </p>
+
+                <label className="flex flex-col gap-[var(--space-1)]">
+                  <span className="font-sans text-xs uppercase tracking-[0.08em]" style={{ color: "var(--text-secondary)" }}>
+                    Email
+                  </span>
+                  <input
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    autoComplete="email"
+                    className="w-full px-[var(--space-3)] py-[var(--space-2)] rounded-[var(--radius-md)] font-sans text-sm border"
+                    style={{ background: "var(--surface, #ffffff)", borderColor: "var(--border, #e0d9cf)" }}
+                  />
+                </label>
+
+                <label className="flex flex-col gap-[var(--space-1)]">
+                  <span className="font-sans text-xs uppercase tracking-[0.08em]" style={{ color: "var(--text-secondary)" }}>
+                    What will you use this for?
+                  </span>
+                  <input
+                    type="text"
+                    value={intendedUse}
+                    onChange={(e) => setIntendedUse(e.target.value)}
+                    maxLength={500}
+                    placeholder="e.g. pitching an internal product idea at work"
+                    className="w-full px-[var(--space-3)] py-[var(--space-2)] rounded-[var(--radius-md)] font-sans text-sm border"
+                    style={{ background: "var(--surface, #ffffff)", borderColor: "var(--border, #e0d9cf)" }}
+                  />
+                </label>
+
+                {error && (
+                  <p
+                    role="alert"
+                    className="font-sans text-sm"
+                    style={{ color: "var(--color-contradicted-fg)" }}
+                  >
+                    {error}
+                  </p>
+                )}
+
+                <div className="flex flex-col sm:flex-row gap-[var(--space-3)]">
+                  <button
+                    type="submit"
+                    disabled={submitting}
+                    className="outline-btn inline-flex items-center justify-center px-[var(--space-5)] py-[var(--space-3)] rounded-[var(--radius-md)] font-sans text-sm font-medium border disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {submitting ? "Sending..." : "Send me the bundle"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={closeModal}
+                    disabled={submitting}
+                    className="inline-flex items-center justify-center px-[var(--space-5)] py-[var(--space-3)] rounded-[var(--radius-md)] font-sans text-sm disabled:opacity-40"
+                    style={{ color: "var(--text-secondary)" }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -75,6 +75,51 @@ export async function notifyWaitlistSignup(entry: WaitlistEntry): Promise<void> 
 }
 
 /**
+ * Send a notification email about a Wizard-of-Oz pricing-intent click.
+ * Fire-and-forget — never throws, never blocks the calling code.
+ */
+export async function notifyWozIntent(entry: {
+  email: string;
+  chosenOption: "one_off" | "subscription";
+  intendedUse: string;
+  ideaSummary: string;
+  ip: string;
+  ts: string;
+}): Promise<void> {
+  const resend = getResend();
+  const to = process.env.WAITLIST_NOTIFY_EMAIL;
+  const from = process.env.WAITLIST_FROM_EMAIL || "onboarding@resend.dev";
+
+  if (!resend || !to) {
+    if (!resend) console.warn("[notifications] RESEND_API_KEY unset — WoZ notifications disabled");
+    if (!to) console.warn("[notifications] WAITLIST_NOTIFY_EMAIL unset — WoZ notifications disabled");
+    return;
+  }
+
+  const optionLabel =
+    entry.chosenOption === "one_off"
+      ? "£4.99 one-off"
+      : "£9.99/mo subscription";
+  const subject = `[ProveIt WoZ] ${optionLabel} — ${entry.email}`;
+
+  try {
+    const { error } = await resend.emails.send({
+      from,
+      to: [to],
+      replyTo: entry.email,
+      subject,
+      html: renderWozHtml(entry, optionLabel),
+      text: renderWozText(entry, optionLabel),
+    });
+    if (error) {
+      console.error("[notifications] Resend WoZ send error (swallowed):", error);
+    }
+  } catch (err) {
+    console.error("[notifications] notifyWozIntent threw (swallowed):", err);
+  }
+}
+
+/**
  * Test-only — reset the cached Resend client.
  */
 export function resetNotificationClient(): void {
@@ -116,6 +161,72 @@ function renderHtml(entry: WaitlistEntry): string {
   </div>
 </body>
 </html>`;
+}
+
+function renderWozHtml(
+  entry: {
+    email: string;
+    intendedUse: string;
+    ideaSummary: string;
+    ip: string;
+    ts: string;
+  },
+  optionLabel: string
+): string {
+  const intendedBlock = entry.intendedUse
+    ? `<p style="margin: 16px 0 8px; font-size: 13px; color: #6a8a8a; text-transform: uppercase; letter-spacing: 0.08em;">Intended use</p>
+       <p style="margin: 0 0 16px; padding: 12px 16px; background: #f0eee8; border-left: 3px solid #c4956a; border-radius: 4px; font-size: 14px; color: #2d2a26;">${escapeHtml(entry.intendedUse)}</p>`
+    : "";
+  const ideaBlock = entry.ideaSummary
+    ? `<p style="margin: 16px 0 8px; font-size: 13px; color: #6a8a8a; text-transform: uppercase; letter-spacing: 0.08em;">Idea they validated</p>
+       <p style="margin: 0 0 16px; padding: 12px 16px; background: #f0eee8; border-left: 3px solid #6a8a8a; border-radius: 4px; font-size: 14px; color: #2d2a26;">${escapeHtml(entry.ideaSummary)}</p>`
+    : "";
+
+  return `<!doctype html>
+<html>
+<body style="margin: 0; padding: 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #faf6f1; color: #2d2a26;">
+  <div style="max-width: 540px; margin: 0 auto; background: #ffffff; padding: 28px; border-radius: 12px; border: 1px solid #e0d9cf;">
+    <p style="margin: 0 0 4px; font-size: 12px; color: #6a8a8a; text-transform: uppercase; letter-spacing: 0.12em;">ProveIt — WoZ pricing intent</p>
+    <h1 style="margin: 0 0 16px; font-family: 'Playfair Display', Georgia, serif; font-size: 22px; font-weight: 500; color: #111a24;">Someone wants the bundle.</h1>
+    <p style="margin: 0 0 16px; font-size: 14px;"><strong>Chose:</strong> ${escapeHtml(optionLabel)}</p>
+    <p style="margin: 0 0 16px; font-size: 14px;"><strong>Email:</strong> <a href="mailto:${escapeHtml(entry.email)}" style="color: #c4956a; text-decoration: none;">${escapeHtml(entry.email)}</a></p>
+    <p style="margin: 0 0 16px; font-size: 14px;"><strong>From IP:</strong> ${escapeHtml(entry.ip)}</p>
+    <p style="margin: 0 0 16px; font-size: 14px;"><strong>When:</strong> ${escapeHtml(entry.ts)}</p>
+    ${intendedBlock}
+    ${ideaBlock}
+    <hr style="margin: 20px 0; border: 0; border-top: 1px solid #e0d9cf;" />
+    <p style="margin: 0; font-size: 13px; color: #6b5d4f;">Manually email the bundle within 4 hours. Hitting <strong>Reply</strong> goes to the submitter. Full list: <a href="https://supabase.com/dashboard/project/bbpdicijaqoujnpidiho/editor" style="color: #c4956a;">Supabase dashboard</a>.</p>
+  </div>
+</body>
+</html>`;
+}
+
+function renderWozText(
+  entry: {
+    email: string;
+    intendedUse: string;
+    ideaSummary: string;
+    ip: string;
+    ts: string;
+  },
+  optionLabel: string
+): string {
+  return [
+    `Someone clicked the ${optionLabel} button on ProveIt.`,
+    "",
+    `Chose:   ${optionLabel}`,
+    `Email:   ${entry.email}`,
+    `From IP: ${entry.ip}`,
+    `When:    ${entry.ts}`,
+    entry.intendedUse ? `\nIntended use:\n  ${entry.intendedUse}` : "",
+    entry.ideaSummary ? `\nIdea they validated:\n  ${entry.ideaSummary}` : "",
+    "",
+    "Manually email the bundle within 4 hours.",
+    "Hitting Reply emails the submitter directly.",
+    "Read the WoZ list: https://supabase.com/dashboard/project/bbpdicijaqoujnpidiho/editor",
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function renderText(entry: WaitlistEntry): string {

--- a/web/src/lib/woz-intent.ts
+++ b/web/src/lib/woz-intent.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+/**
+ * Wizard-of-Oz pricing-intent capture.
+ *
+ * When a user clicks "Get the bundle — £4.99" or "Subscribe — £9.99/mo" on
+ * the Full Validation completion screen, we record the click as an *intent*
+ * (no Stripe yet) so we get pricing-format signal for the friend-cohort
+ * Week 1 launch. Claire then manually emails the bundle within 4 hours.
+ *
+ * Storage: Supabase table `public.woz_intents`. RLS on, anon key has
+ * INSERT-only via `anon_can_insert_woz_intents`.
+ *
+ * Schema (see migration `create_woz_intents_table`):
+ *   id            bigint identity primary key
+ *   email         text not null
+ *   chosen_option text not null check (in 'one_off' | 'subscription')
+ *   intended_use  text nullable
+ *   idea_summary  text nullable
+ *   ip            text nullable
+ *   created_at    timestamptz default now()
+ *
+ * Fail open on Supabase errors — better to silently lose a submission than
+ * break the form for the user. Errors are logged.
+ *
+ * Local dev / tests: when SUPABASE_URL or SUPABASE_PUBLISHABLE_KEY are
+ * unset, falls back to an in-memory list.
+ */
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let _supabase: SupabaseClient | null | undefined;
+
+function getSupabase(): SupabaseClient | null {
+  if (_supabase !== undefined) return _supabase;
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_PUBLISHABLE_KEY;
+  _supabase = url && key ? createClient(url, key) : null;
+  return _supabase;
+}
+
+const memoryStore: WozIntent[] = [];
+
+export type WozOption = "one_off" | "subscription";
+
+export interface WozIntent {
+  email: string;
+  chosenOption: WozOption;
+  intendedUse: string;
+  ideaSummary: string;
+  ip: string;
+  ts: string;
+}
+
+export interface WozIntentInput {
+  email: string;
+  chosenOption: WozOption;
+  intendedUse?: string;
+  ideaSummary?: string;
+  ip: string;
+}
+
+export async function recordWozIntent(input: WozIntentInput): Promise<void> {
+  const entry: WozIntent = {
+    email: input.email.trim().toLowerCase(),
+    chosenOption: input.chosenOption,
+    intendedUse: (input.intendedUse ?? "").slice(0, 500),
+    ideaSummary: (input.ideaSummary ?? "").slice(0, 500),
+    ip: input.ip,
+    ts: new Date().toISOString(),
+  };
+
+  const supabase = getSupabase();
+  try {
+    if (supabase) {
+      const { error } = await supabase.from("woz_intents").insert({
+        email: entry.email,
+        chosen_option: entry.chosenOption,
+        intended_use: entry.intendedUse || null,
+        idea_summary: entry.ideaSummary || null,
+        ip: entry.ip,
+      });
+      if (error) {
+        console.error("[woz-intent] Supabase insert error (swallowed):", error);
+      }
+    } else {
+      memoryStore.push(entry);
+    }
+  } catch (err) {
+    console.error("[woz-intent] recordWozIntent threw (swallowed):", err);
+  }
+}
+
+export function resetWozIntentStores(): void {
+  memoryStore.length = 0;
+  _supabase = undefined;
+}
+
+export function _getMemoryWozIntents(): readonly WozIntent[] {
+  return memoryStore;
+}

--- a/web/tests/unit/full-bundle-pointer.test.tsx
+++ b/web/tests/unit/full-bundle-pointer.test.tsx
@@ -1,28 +1,65 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import FullBundlePointer from "@/components/validate/FullBundlePointer";
 
 describe("FullBundlePointer", () => {
-  it("links to Claude Code with the right href and target attributes", () => {
-    render(<FullBundlePointer />);
-    const link = screen.getByRole("link", { name: /claude code/i });
-    expect(link).toHaveAttribute("href", "https://claude.com/claude-code");
-    expect(link).toHaveAttribute("target", "_blank");
-    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  beforeEach(() => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    );
   });
 
-  it("mentions the new artefacts the bundle contains", () => {
-    const { container } = render(<FullBundlePointer />);
-    const text = container.textContent ?? "";
-    expect(text).toContain("discovery.md");
-    expect(text).toContain("brand.md");
-    expect(text).toContain("spec.md");
-    expect(text).toContain("design-brief.md");
-    expect(text).toContain("Claude Design prompts");
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it("describes the CLI alternative as free", () => {
+  it("renders both pricing buttons and the free Claude Code fallback", () => {
     render(<FullBundlePointer />);
-    expect(screen.getByText(/free, full pipeline/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /£4\.99.*one-off/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /£9\.99\/mo/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /claude code/i })
+    ).toHaveAttribute("href", "https://claude.com/claude-code");
+  });
+
+  it("opens the modal with the one-off label when £4.99 is clicked", () => {
+    render(<FullBundlePointer />);
+    fireEvent.click(screen.getByRole("button", { name: /£4\.99.*one-off/i }));
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog.textContent).toMatch(/£4\.99 \(one-off\)/);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/what will you use this for/i)).toBeInTheDocument();
+  });
+
+  it("POSTs to /api/woz-intent with the chosen option and shows the confirmation", async () => {
+    render(<FullBundlePointer />);
+    fireEvent.click(screen.getByRole("button", { name: /£9\.99\/mo/i }));
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/what will you use this for/i), {
+      target: { value: "demo use case" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send me the bundle/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/woz-intent",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.chosenOption).toBe("subscription");
+    expect(body.email).toBe("test@example.com");
+    expect(body.intendedUse).toBe("demo use case");
+
+    await screen.findByText(/Claire will personally email you the bundle within 4 hours/i);
   });
 });


### PR DESCRIPTION
## Summary

Closes #30 — replace `FullBundlePointer`'s CLI-only message with two pricing buttons (£4.99 one-off / £9.99/mo) backed by a Wizard-of-Oz modal that captures the click-intent without charging. Claire then manually emails the bundle within 4 hours. This is the Week 1 launch test mechanic.

- New `POST /api/woz-intent` (zod-validated, rate-limited via the existing fast bucket — 10/IP/min)
- New `src/lib/woz-intent.ts` — Supabase insert + in-memory test fallback, mirrors `lib/waitlist.ts`
- New `notifyWozIntent()` in `lib/notifications.ts` — Resend email to `WAITLIST_NOTIFY_EMAIL` with chosen option + intended use + the validated idea, so Claire can reply within 4 hours
- Supabase migration `create_woz_intents_table` — RLS on, anon INSERT-only, indexed on `created_at desc`. Already applied to `proveit-web`.
- Accessible modal (`role=dialog`, `aria-modal=true`, backdrop-click close). CLI fallback line preserved below the buttons.

## Test plan

- [x] 235/235 unit tests passing locally (3 new tests on `FullBundlePointer`: buttons render, modal opens, POSTs correct payload + shows confirmation)
- [x] `pnpm lint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean — `/api/woz-intent` registered as a dynamic route
- [x] Local smoke test: `POST /api/woz-intent` against `pnpm start` returns `200 {"ok":true}` (in-memory fallback, no local Supabase env vars)
- [ ] Vercel preview smoke test: click both buttons, fill form, confirm row in Supabase `woz_intents` + Resend email arrives at `cla1re@me.com`
- [ ] Confirm Tier-up: when this lands, the next Project #4 priority is #41 (mobile streaming verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)