### PR TITLE
fix: compact phase indicator on mobile (#41)

### DIFF
--- a/web/src/components/validate/PhaseIndicator.tsx
+++ b/web/src/components/validate/PhaseIndicator.tsx
@@ -23,52 +23,93 @@ function getActiveStep(phase: DiscoveryPhase): number {
 export default function PhaseIndicator({ phase }: PhaseIndicatorProps) {
   const activeStep = getActiveStep(phase);
   const isActive = phase !== "complete";
+  const activeLabel = PHASES[activeStep].label;
 
   return (
-    <div className="flex items-center gap-[var(--space-4)]">
-      {PHASES.map((p, i) => {
-        const isCurrentStep = i === activeStep;
-        return (
-          <div key={p.label} className="flex items-center gap-[var(--space-2)]">
-            <span
-              className="font-sans"
-              style={{
-                fontSize: "var(--text-xs)",
-                letterSpacing: "0.08em",
-                color: isCurrentStep
-                  ? "var(--text-primary)"
-                  : "var(--text-muted)",
-                fontWeight: isCurrentStep ? 500 : 400,
-                transition: "color var(--duration-base)",
-              }}
-            >
-              {p.label}
-            </span>
-            {isCurrentStep && isActive && (
-              <span
-                className="inline-block w-1.5 h-1.5 rounded-full"
-                style={{
-                  backgroundColor: "var(--color-accent)",
-                  animation: "dot-pulse 1.4s ease-in-out infinite",
-                }}
-                aria-hidden="true"
-              />
-            )}
-            {i < PHASES.length - 1 && (
+    <>
+      {/* Mobile (<640px): compact "N/4 · ACTIVE_LABEL" so the row fits next to the idea bar */}
+      <div className="sm:hidden flex items-center gap-[var(--space-2)] shrink-0">
+        <span
+          className="font-sans"
+          style={{
+            fontSize: "var(--text-xs)",
+            letterSpacing: "0.08em",
+            color: "var(--text-muted)",
+          }}
+          aria-hidden="true"
+        >
+          {activeStep + 1}/{PHASES.length}
+        </span>
+        <span
+          className="font-sans"
+          style={{
+            fontSize: "var(--text-xs)",
+            letterSpacing: "0.08em",
+            color: "var(--text-primary)",
+            fontWeight: 500,
+          }}
+          aria-label={`Phase ${activeStep + 1} of ${PHASES.length}: ${activeLabel}`}
+        >
+          {activeLabel}
+        </span>
+        {isActive && (
+          <span
+            className="inline-block w-1.5 h-1.5 rounded-full"
+            style={{
+              backgroundColor: "var(--color-accent)",
+              animation: "dot-pulse 1.4s ease-in-out infinite",
+            }}
+            aria-hidden="true"
+          />
+        )}
+      </div>
+
+      {/* Desktop (≥640px): full chain */}
+      <div className="hidden sm:flex items-center gap-[var(--space-4)]">
+        {PHASES.map((p, i) => {
+          const isCurrentStep = i === activeStep;
+          return (
+            <div key={p.label} className="flex items-center gap-[var(--space-2)]">
               <span
                 className="font-sans"
                 style={{
                   fontSize: "var(--text-xs)",
-                  color: "var(--text-muted)",
-                  marginLeft: "var(--space-2)",
+                  letterSpacing: "0.08em",
+                  color: isCurrentStep
+                    ? "var(--text-primary)"
+                    : "var(--text-muted)",
+                  fontWeight: isCurrentStep ? 500 : 400,
+                  transition: "color var(--duration-base)",
                 }}
               >
-                /
+                {p.label}
               </span>
-            )}
-          </div>
-        );
-      })}
-    </div>
+              {isCurrentStep && isActive && (
+                <span
+                  className="inline-block w-1.5 h-1.5 rounded-full"
+                  style={{
+                    backgroundColor: "var(--color-accent)",
+                    animation: "dot-pulse 1.4s ease-in-out infinite",
+                  }}
+                  aria-hidden="true"
+                />
+              )}
+              {i < PHASES.length - 1 && (
+                <span
+                  className="font-sans"
+                  style={{
+                    fontSize: "var(--text-xs)",
+                    color: "var(--text-muted)",
+                    marginLeft: "var(--space-2)",
+                  }}
+                >
+                  /
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/web/tests/unit/phase-indicator.test.tsx
+++ b/web/tests/unit/phase-indicator.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PhaseIndicator from "@/components/validate/PhaseIndicator";
+
+describe("PhaseIndicator", () => {
+  it("renders the mobile compact label (current phase + step counter)", () => {
+    render(<PhaseIndicator phase="brain_dump" />);
+    const compact = screen.getByLabelText(/Phase 1 of 4: BRAIN DUMP/);
+    expect(compact).toBeInTheDocument();
+    expect(compact.parentElement?.className).toContain("sm:hidden");
+  });
+
+  it("renders the full chain for sm+ viewports (all 4 labels present)", () => {
+    render(<PhaseIndicator phase="discovery" />);
+    expect(screen.getAllByText("BRAIN DUMP").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("DISCOVERY").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("RESEARCH").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("RESULTS").length).toBeGreaterThan(0);
+  });
+
+  it("marks the correct active step on the mobile label across phases", () => {
+    const { rerender } = render(<PhaseIndicator phase="research" />);
+    expect(screen.getByLabelText(/Phase 3 of 4: RESEARCH/)).toBeInTheDocument();
+
+    rerender(<PhaseIndicator phase="findings" />);
+    expect(screen.getByLabelText(/Phase 4 of 4: RESULTS/)).toBeInTheDocument();
+
+    rerender(<PhaseIndicator phase="complete" />);
+    expect(screen.getByLabelText(/Phase 4 of 4: RESULTS/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the top-bar overflow part of #41. Below sm: (640px) the four-step phase chain (BRAIN DUMP / DISCOVERY / RESEARCH / RESULTS) overflowed the iPhone SE and iPhone 14 Pro viewports, cropping RESULTS and pushing the "Idea: …" text to zero-width in the flex row.

- New mobile branch in \`PhaseIndicator\`: \`N/4 · ACTIVE_LABEL · pulse-dot\`
- Original full chain preserved for sm: and up
- aria-label \`Phase N of 4: LABEL\` on the compact element for screen readers
- 3 new unit tests (238/238 passing)

Verified on Playwright at 375×667 (iPhone SE), 393×852 (iPhone 14 Pro). No overflow at 768 (iPad).

## Out of scope (separate follow-up)

Score-panel-below-chat-input is also a mobile UX wart but not a blocker — the panel is mostly empty during Brain Dump where Substack/LinkedIn arrivals first land. Filing as a separate \`mobile-cosmetic\` issue.

## Test plan

- [x] \`pnpm test --run\` — 238/238 passing
- [x] \`pnpm lint\` clean
- [x] \`pnpm exec tsc --noEmit\` clean
- [ ] After deploy: hit proveit.tools/validate at 375×667 — top bar fits, idea text visible, current phase label readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)