### PR TITLE
fix: move score panel above chat input on mobile (#47)

### DIFF
--- a/web/src/components/validate/ChatInterface.tsx
+++ b/web/src/components/validate/ChatInterface.tsx
@@ -548,6 +548,11 @@ export default function ChatInterface() {
 
   const isComplete = activeSession.phase === "complete";
   const canDownload = activeSession.phase === "findings" || activeSession.phase === "complete";
+  const hasScorePanelContent =
+    activeSession.scores.desirability !== null ||
+    activeSession.scores.viability !== null ||
+    activeSession.scores.feasibility !== null ||
+    activeSession.killSignals.length > 0;
 
   return (
     <div className="flex flex-col lg:flex-row flex-1" style={{ maxHeight: "calc(100vh - 56px)" }}>
@@ -634,6 +639,23 @@ export default function ChatInterface() {
           )}
         </div>
 
+        {/* Score panel — mobile inline placement, between messages and chat input.
+            Suppressed during Brain Dump / Discovery when no scores have arrived yet
+            (the empty-state filler wastes vertical real estate on small screens).
+            Hidden on lg:+ where the sidebar at right takes over. */}
+        {hasScorePanelContent && (
+          <div
+            className="lg:hidden border-t shrink-0 max-h-[40vh] overflow-y-auto p-[var(--space-4)]"
+            style={{ borderColor: "var(--border-subtle)" }}
+          >
+            <ScorePanel
+              scores={activeSession.scores}
+              killSignals={activeSession.killSignals}
+              phase={activeSession.phase}
+            />
+          </div>
+        )}
+
         {/* Chat input bar — sticky bottom */}
         <div className="shrink-0">
           <ChatInput
@@ -646,9 +668,9 @@ export default function ChatInterface() {
         </div>
       </div>
 
-      {/* Score panel — sidebar on desktop */}
+      {/* Score panel — sidebar on desktop only */}
       <div
-        className="lg:w-72 xl:w-80 border-t lg:border-t-0 lg:border-l p-[var(--space-4)] overflow-y-auto"
+        className="hidden lg:block lg:w-72 xl:w-80 lg:border-l p-[var(--space-4)] overflow-y-auto"
         style={{ borderColor: "var(--border-subtle)" }}
       >
         <ScorePanel


### PR DESCRIPTION
## Summary

Closes #47 — on <1024px the score panel rendered below the sticky chat input, so users had to scroll past their typing area to see scores. Backwards reading order.

- Mobile (<lg): inline ScorePanel between messages and ChatInput, capped at \`max-h-[40vh]\` with \`overflow-y-auto\`
- Desktop (lg+): right sidebar unchanged
- Suppress mobile inline panel during Brain Dump / Discovery when no scores exist — the empty-state filler wastes vertical space

## Test plan

- [x] 238/238 unit tests passing
- [x] \`pnpm lint\` + \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm build\` clean
- [ ] Vercel preview: at 375×667, drive a session into research phase, confirm scores appear above input (not below)
- [ ] Desktop sidebar visually unchanged at lg:+ breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)