### PR TITLE
feat: PostHog error tracking client + server (#42)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -94,6 +94,8 @@ For local dev, Upstash isn't required — the in-memory rate limiter is sufficie
 | `RESEND_API_KEY` | Recommended in production | Resend API key for waitlist notification emails. Without it, submissions still land in Supabase but no email alert fires. | [resend.com](https://resend.com) — free tier 100 emails/day |
 | `WAITLIST_NOTIFY_EMAIL` | Recommended in production | Address that receives the "new waitlist signup" notification email | Your own email |
 | `WAITLIST_FROM_EMAIL` | Optional | From-address for notification emails. Defaults to `onboarding@resend.dev` (only delivers to your registered Resend email). Set to a verified-domain address once Resend domain verification is set up. | Resend dashboard |
+| `NEXT_PUBLIC_POSTHOG_KEY` | Recommended in production | PostHog project key for analytics + error tracking. Without it, both feature analytics (#29) and error capture (#42) are no-ops; the app still functions. | [posthog.com](https://posthog.com) project settings |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Optional | PostHog ingestion host. Defaults to `https://eu.i.posthog.com`. | — |
 | `ALLOWED_ORIGIN` | Optional | Override the CORS allowed origin (defaults to the request `Host`) | — |
 
 **Web search must be enabled.** Full Validation runs a live web research phase using Anthropic's native web search tool. An admin on your Anthropic Console account must enable it at **Settings → Privacy → Web Search**, otherwise the research phase fails. Fast Check doesn't need it.
@@ -202,6 +204,8 @@ A few non-obvious decisions worth knowing before touching the code:
 **Client IP detection trusts `x-real-ip` first, then the LAST entry of `x-forwarded-for`.** Never the first entry of `x-forwarded-for` — that's user-controlled and trivially spoofed. The last entry is the address Vercel's edge actually saw.
 
 **Roami Design System.** The palette and typography are vendored from `@roami/design-system` v1.1.0 into `src/app/roami-tokens.css`. The existing ProveIt CSS variable names (`--bg-base`, `--text-primary`, `--color-accent`) are preserved and now resolve to Roami values, so component code is unchanged. Playfair Display is used for the wordmark and the home hero; system-ui for body and UI; Fira Code is reserved for genuinely technical content (search-query echoes, code blocks).
+
+**Error tracking via PostHog (#42).** Client-side exceptions are autocaptured (`capture_exceptions: true` in `src/lib/posthog.ts`) and route-level error boundaries (`src/app/error.tsx`, `src/app/global-error.tsx`) forward errors via `posthog.captureException`. Server-side errors are forwarded from `instrumentation.ts` via the Next.js `onRequestError` hook, plus manual `captureServerException` calls inside the `/api/chat` and `/api/fast` Anthropic streaming catch blocks. The server client lives in `src/lib/posthog-server.ts` and reuses the same `NEXT_PUBLIC_POSTHOG_KEY` env var as the client SDK. **PII discipline:** the user's idea text and chat content are NEVER passed to PostHog. Properties on captures are restricted to route metadata (path, method, Anthropic status code, error type). View errors in the [PostHog activity feed](https://eu.posthog.com/activity/explore) (filter by event `$exception`); to be alerted in real time, configure a notification rule in PostHog → Error Tracking → Alerts → route to `cla1re@me.com`. Source-map upload is a follow-up — see PostHog docs for the build-time plugin.
 
 ---
 

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,0 +1,78 @@
+/**
+ * Next.js instrumentation hook — captures server-side errors via PostHog.
+ *
+ * Story #42. The `onRequestError` hook fires for any uncaught error in a
+ * server component, server action, route handler, or middleware. We forward
+ * it to PostHog for the maintainer to see in the activity feed.
+ *
+ * Runtime guard: PostHog Node SDK only works in the nodejs runtime. Edge
+ * runtime errors are skipped (we don't deploy edge functions for ProveIt).
+ *
+ * PII: pass route metadata only — no headers other than path, method, and
+ * the PostHog distinct_id cookie (so errors link to the right user). Idea
+ * text, chat messages, and emails must stay private.
+ */
+
+export function register(): void {
+  // No-op for now. Add server-side singletons here if they need lazy init.
+}
+
+interface NextRequestErrorContext {
+  routerKind: "Pages Router" | "App Router";
+  routePath: string;
+  routeType: "render" | "route" | "action" | "middleware";
+}
+
+interface NextRequestErrorRequest {
+  path?: string;
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+}
+
+export const onRequestError = async (
+  err: unknown,
+  request: NextRequestErrorRequest,
+  context: NextRequestErrorContext
+): Promise<void> => {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  // Lazy-require avoids loading posthog-node into the edge runtime bundle.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { captureServerException } = require("./src/lib/posthog-server") as typeof import("./src/lib/posthog-server");
+
+  // Extract the PostHog distinct_id from the cookie so the error attaches
+  // to the same person as their session events. Cookie format set by
+  // posthog-js: `ph_<key>_posthog={"distinct_id":"..."}`.
+  let distinctId: string | undefined;
+  const cookieHeader = request.headers?.cookie;
+  if (cookieHeader) {
+    const cookieString = Array.isArray(cookieHeader)
+      ? cookieHeader.join("; ")
+      : cookieHeader;
+    const match = cookieString.match(/ph_[^=]+?_posthog=([^;]+)/);
+    if (match?.[1]) {
+      try {
+        const decoded = decodeURIComponent(match[1]);
+        const parsed = JSON.parse(decoded) as { distinct_id?: string };
+        if (typeof parsed.distinct_id === "string") {
+          distinctId = parsed.distinct_id;
+        }
+      } catch {
+        // Malformed cookie — fall through with no distinctId.
+      }
+    }
+  }
+
+  await captureServerException(
+    err,
+    {
+      source: "instrumentation_onRequestError",
+      route_path: context.routePath,
+      route_kind: context.routerKind,
+      route_type: context.routeType,
+      request_method: request.method,
+      request_path: request.path,
+    },
+    distinctId
+  );
+};

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "nanoid": "5.1.5",
         "next": "^15.3.9",
         "posthog-js": "^1.372.10",
+        "posthog-node": "^5.34.2",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-markdown": "^10.1.0",
@@ -589,6 +590,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
       "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -610,6 +612,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1797,6 +1800,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3009,6 +3013,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.0.tgz",
@@ -3209,6 +3271,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9250,6 +9313,41 @@
         "query-selector-shadow-dom": "^1.0.1",
         "web-vitals": "^5.1.0"
       }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.34.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.34.2.tgz",
+      "integrity": "sha512-lGp7zyyvzNZqrto3CPq3nQzVn9ZUg5tApE8jNh12Cu8kOqT9KTABZ8kMgiybfzxVttSdE3m25RsBPLBHkxCWDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.29.2"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/posthog-node/node_modules/@posthog/core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.2.tgz",
+      "integrity": "sha512-DYhR0Sl7pVdUXa+C9poCVjTj3D6SI9P7RLhIhr74YyHeHuCGL/MZsDEWcz3ul3qHDIhZU9myIUjID890QiQw+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.373.5"
+      }
+    },
+    "node_modules/posthog-node/node_modules/@posthog/types": {
+      "version": "1.373.5",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.373.5.tgz",
+      "integrity": "sha512-K7STCnRG/WBE1q0BwEkIcrJB5OqECaymsQj6Hp4Ntvaek4dqHkZGfp6hxwIPqQPjlOXwidwPLo+XGsn+CoZUyw==",
+      "license": "MIT"
     },
     "node_modules/preact": {
       "version": "10.29.1",

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "nanoid": "5.1.5",
     "next": "^15.3.9",
     "posthog-js": "^1.372.10",
+    "posthog-node": "^5.34.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-markdown": "^10.1.0",

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import { anthropic } from "@/lib/anthropic";
 import { buildChatSystemPrompt } from "@/lib/prompts";
 import { checkRateLimit, getClientIp, RATE_LIMITS } from "@/lib/rate-limit";
 import { checkSpend, estimateCost, recordSpend } from "@/lib/spend-ledger";
+import { captureServerException } from "@/lib/posthog-server";
 
 export const runtime = "nodejs";
 export const maxDuration = 300;
@@ -298,6 +299,15 @@ export async function POST(req: NextRequest) {
           );
         } else {
           console.error("[/api/chat] Anthropic error:", err);
+          // Unexpected — forward to PostHog so the maintainer sees it. Send
+          // only route metadata and Anthropic's own status/error type. The
+          // user's idea text and chat content are NOT included.
+          await captureServerException(err, {
+            route: "/api/chat",
+            anthropic_status: anthropicErr.status,
+            anthropic_error_type: anthropicErr.error?.type,
+            anthropic_error_name: anthropicErr.name,
+          });
           controller.enqueue(
             encoder.encode(
               '\ndata: {"type":"error","message":"Something went wrong. Please try again."}\n'

--- a/web/src/app/api/fast/route.ts
+++ b/web/src/app/api/fast/route.ts
@@ -5,6 +5,7 @@ import { anthropic } from "@/lib/anthropic";
 import { buildFastCheckPrompt } from "@/lib/prompts";
 import { checkRateLimit, getClientIp, RATE_LIMITS } from "@/lib/rate-limit";
 import { checkSpend, estimateCost, recordSpend } from "@/lib/spend-ledger";
+import { captureServerException } from "@/lib/posthog-server";
 
 export const runtime = "nodejs";
 export const maxDuration = 300;
@@ -159,6 +160,14 @@ export async function POST(req: NextRequest) {
           );
         } else {
           console.error("[/api/fast] Anthropic error:", err);
+          // Unexpected — forward to PostHog. Route metadata + Anthropic
+          // status only; the user's idea content is NOT included.
+          await captureServerException(err, {
+            route: "/api/fast",
+            anthropic_status: anthropicErr.status,
+            anthropic_error_type: anthropicErr.error?.type,
+            anthropic_error_name: anthropicErr.name,
+          });
           controller.enqueue(
             encoder.encode(
               '\ndata: {"type":"error","message":"Something went wrong. Please try again."}\n'

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+
+/**
+ * Route-level error boundary (Next.js App Router).
+ *
+ * Catches uncaught errors rendered in any page below /app and reports them
+ * to PostHog so the maintainer sees them in the activity feed.
+ *
+ * PII discipline: we only pass the Error object (name, message, stack). We
+ * do NOT include any user-typed content — the idea text and chat messages
+ * stay private.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    posthog.captureException(error, { source: "app_route_error_boundary" });
+  }, [error]);
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center p-[var(--space-8)]"
+      style={{ background: "var(--bg-canvas)" }}
+    >
+      <div
+        className="max-w-md text-center flex flex-col gap-[var(--space-4)]"
+        style={{ color: "var(--text-primary)" }}
+      >
+        <h1
+          className="font-display text-2xl"
+          style={{ color: "var(--heading, #111a24)" }}
+        >
+          Something went wrong.
+        </h1>
+        <p className="font-sans text-sm" style={{ color: "var(--text-secondary)" }}>
+          The page hit an unexpected error. The maintainer has been notified.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="outline-btn self-center inline-flex items-center justify-center px-[var(--space-5)] py-[var(--space-3)] rounded-[var(--radius-md)] font-sans text-sm font-medium border"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+
+/**
+ * Root-level error boundary (Next.js App Router).
+ *
+ * Fires for errors in the root layout / providers, which the route-level
+ * error.tsx cannot catch. Must include its own <html> + <body>.
+ *
+ * PII: we only pass the Error object. No idea text, no chat content.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    posthog.captureException(error, { source: "app_global_error_boundary" });
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          padding: "48px 24px",
+          fontFamily:
+            "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          background: "#faf6f1",
+          color: "#2d2a26",
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div style={{ maxWidth: 480, textAlign: "center" }}>
+          <h1
+            style={{
+              margin: "0 0 16px",
+              fontFamily: "'Playfair Display', Georgia, serif",
+              fontSize: 24,
+              fontWeight: 500,
+              color: "#111a24",
+            }}
+          >
+            ProveIt is having a moment.
+          </h1>
+          <p style={{ margin: "0 0 24px", fontSize: 14, color: "#6b5d4f" }}>
+            Something deep in the app threw an error. The maintainer has been
+            notified. Try refreshing — if it sticks, drop a note to{" "}
+            <a href="mailto:cla1re@me.com" style={{ color: "#c4956a" }}>
+              cla1re@me.com
+            </a>
+            .
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              padding: "10px 20px",
+              border: "1px solid #c4956a",
+              background: "transparent",
+              color: "#c4956a",
+              fontSize: 14,
+              borderRadius: 6,
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/src/lib/posthog-server.ts
+++ b/web/src/lib/posthog-server.ts
@@ -1,0 +1,80 @@
+import "server-only";
+
+/**
+ * Server-side PostHog client for error tracking + telemetry from API routes.
+ *
+ * Story #42 / Epic #24 pre-launch error tracking. Mirrors the client-side
+ * posthog-js wiring (lib/posthog.ts) so server errors land in the same
+ * project as client errors.
+ *
+ * Env vars: reuses NEXT_PUBLIC_POSTHOG_KEY + NEXT_PUBLIC_POSTHOG_HOST
+ * (already provisioned for client analytics in #29). No new env vars needed.
+ *
+ * PII: callers must not pass user-typed content (idea text, chat messages,
+ * email addresses) in properties. Pass only error objects + non-PII context
+ * like the route path, request method, and rate-limit bucket.
+ *
+ * Failure mode: quiet no-op when env vars are unset. Errors during capture
+ * are swallowed and logged — never throw to the caller.
+ *
+ * Lifecycle: singleton so we share the in-flight queue across requests.
+ * flushAt: 1 + flushInterval: 0 means events are sent immediately (no
+ * batching) — important in a serverless function where the process may
+ * terminate before a normal flush.
+ */
+
+import { PostHog } from "posthog-node";
+
+let _client: PostHog | null | undefined;
+
+export function getPostHogServer(): PostHog | null {
+  if (_client !== undefined) return _client;
+
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) {
+    console.warn("[posthog-server] NEXT_PUBLIC_POSTHOG_KEY unset — server error tracking disabled");
+    _client = null;
+    return _client;
+  }
+
+  const host =
+    process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.i.posthog.com";
+
+  _client = new PostHog(key, {
+    host,
+    flushAt: 1,
+    flushInterval: 0,
+  });
+  return _client;
+}
+
+/**
+ * Capture a server-side exception. Quiet no-op when PostHog isn't configured.
+ *
+ * Do NOT pass user content in `properties` — the idea text and chat
+ * messages must stay private. Stick to route metadata (path, method, IP
+ * hash, rate-limit bucket).
+ */
+export async function captureServerException(
+  err: unknown,
+  properties: Record<string, unknown> = {},
+  distinctId?: string
+): Promise<void> {
+  const client = getPostHogServer();
+  if (!client) return;
+
+  try {
+    const error = err instanceof Error ? err : new Error(String(err));
+    await client.captureException(error, distinctId, properties);
+  } catch (captureErr) {
+    console.error("[posthog-server] captureException threw (swallowed):", captureErr);
+  }
+}
+
+/**
+ * Test-only — reset the cached client. Used by unit tests so they can
+ * re-evaluate the env-var-based init path.
+ */
+export function resetPostHogServer(): void {
+  _client = undefined;
+}

--- a/web/src/lib/posthog.ts
+++ b/web/src/lib/posthog.ts
@@ -21,6 +21,10 @@ export function initPostHog(): void {
     capture_pageview: "history_change",
     capture_pageleave: true,
     autocapture: true,
+    // Capture unhandled exceptions and Promise rejections on the client.
+    // Stack traces only — no application state, no message content.
+    // Story #42 / Epic #24 pre-launch error tracking.
+    capture_exceptions: true,
     persistence: "localStorage+cookie",
     person_profiles: "identified_only",
     loaded: (ph) => {

--- a/web/tests/unit/posthog-server.test.ts
+++ b/web/tests/unit/posthog-server.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// server-only guard must be mocked before importing the module
+vi.mock("server-only", () => ({}));
+
+const captureExceptionMock = vi.fn();
+
+vi.mock("posthog-node", () => ({
+  PostHog: vi.fn().mockImplementation(() => ({
+    captureException: captureExceptionMock,
+  })),
+}));
+
+import {
+  getPostHogServer,
+  captureServerException,
+  resetPostHogServer,
+} from "@/lib/posthog-server";
+
+describe("posthog-server", () => {
+  beforeEach(() => {
+    resetPostHogServer();
+    captureExceptionMock.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  });
+
+  it("returns null and warns when NEXT_PUBLIC_POSTHOG_KEY is unset", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = getPostHogServer();
+    expect(client).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("NEXT_PUBLIC_POSTHOG_KEY unset"),
+    );
+    warn.mockRestore();
+  });
+
+  it("captureServerException is a quiet no-op when key is unset", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      captureServerException(new Error("boom"), { route: "/api/x" }),
+    ).resolves.toBeUndefined();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards Error + properties + distinctId when key is set", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+    const err = new Error("anthropic exploded");
+    await captureServerException(err, { route: "/api/chat" }, "user-123");
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [sentErr, distinctId, props] = captureExceptionMock.mock.calls[0];
+    expect(sentErr).toBe(err);
+    expect(distinctId).toBe("user-123");
+    expect(props).toEqual({ route: "/api/chat" });
+  });
+
+  it("wraps non-Error values in Error before sending", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+    await captureServerException("string error", { route: "/api/fast" });
+    const [sentErr] = captureExceptionMock.mock.calls[0];
+    expect(sentErr).toBeInstanceOf(Error);
+    expect((sentErr as Error).message).toBe("string error");
+  });
+
+  it("swallows internal capture errors without throwing", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+    captureExceptionMock.mockRejectedValueOnce(new Error("network down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      captureServerException(new Error("first"), { route: "/api/chat" }),
+    ).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #42 — chose **PostHog error tracking** (the alternative the issue explicitly allowed) over adding Sentry. PostHog was already wired for analytics in #29, so this means: no new vendor, no new env vars, no new dashboard, same activity feed.

### Client
- \`capture_exceptions: true\` in \`lib/posthog.ts\` (JS SDK autocapture)
- \`app/error.tsx\` route-level boundary
- \`app/global-error.tsx\` root-layout boundary

### Server
- \`posthog-node\` added
- \`src/lib/posthog-server.ts\` singleton + \`captureServerException()\`
- \`instrumentation.ts\` with \`onRequestError\` hook + cookie distinct_id linking
- Manual \`captureServerException\` in \`/api/chat\` and \`/api/fast\` unexpected-error branches

### PII discipline
No idea text, no chat content. Properties limited to route metadata (path, method, Anthropic status, error type).

## Test plan

- [x] 243/243 unit tests passing locally (5 new on \`posthog-server\`)
- [x] \`pnpm build\` clean — error.tsx + global-error.tsx + /api routes all registered
- [x] tsc clean
- [ ] Vercel preview: trigger a deliberate \`Error\` via \`/api/chat\` with malformed body, confirm event appears in PostHog activity feed within 30s, confirm idea text is NOT in the event properties
- [ ] PostHog Error Tracking → Alerts: set up email notification rule routing to \`cla1re@me.com\` (manual step, documented in README)

## Out of scope (follow-ups)

- **Source-map upload** — production stack traces will be minified for now. PostHog still captures them and resolves file:line. The build-time plugin can be added pre-launch if useful, but not blocking.
- **#43 Anthropic key rotation** — separate security issue, left for Claire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)