### PR TITLE
feat: enforce docs-in-sync-with-code (CI + in-session hook)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,5 +7,19 @@
       "WebSearch",
       "WebFetch"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r \".tool_input.command // empty\"); if printf \"%s\" \"$cmd\" | grep -q \"git commit\"; then s=$(git diff --cached --name-only 2>/dev/null); if printf \"%s\" \"$s\" | grep -qE \"^(scripts/|agents/|commands/)\" && ! printf \"%s\" \"$s\" | grep -qE \"^(README\\.md|CLAUDE\\.md|AGENTS\\.md|docs/)\"; then echo \"docs-sync reminder: code is staged with no docs (README/CLAUDE/AGENTS/docs). Update them, or put [no-docs] in the commit message if none are needed.\"; fi; fi",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,24 @@
+name: Docs sync check
+
+# Flags any PR where agent code (scripts/ agents/ commands/) changed without a
+# corresponding docs update (README/CLAUDE/AGENTS/docs). Overridable: add [no-docs]
+# to a commit message when a change genuinely needs none. Pure bash — no LLM, no
+# secrets, no token cost. Runs in a few seconds.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need history to diff against the base branch
+      - name: Check docs kept in sync with code
+        run: bash scripts/check-docs-sync.sh "origin/${{ github.base_ref }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,16 @@ Research phases are delegated to Sonnet subagents for speed.
 - **Persistence** — `discovery.md` survives across sessions
 - **PM decides** — ProveIt presents evidence, never makes the go/kill call
 
+## Keeping docs in sync with code — enforced
+
+When you change `scripts/`, `agents/`, or `commands/`, update the docs that describe them: `README.md`, `CLAUDE.md`, `AGENTS.md`, and `docs/` (including the directory trees). This is **enforced**, not advisory:
+
+- **CI gate** — `.github/workflows/docs-check.yml` flags any PR where code changed without a doc update (pure bash, no LLM, no token cost).
+- **In-session reminder** — a `PreToolUse` hook in `.claude/settings.json` warns at commit time if code is staged without docs.
+- **Override** — if a change genuinely needs no doc update (e.g. a pure bugfix), put `[no-docs]` in a commit message. The check then passes.
+
+Shared logic lives in `scripts/check-docs-sync.sh`.
+
 ## Security
 
 This project commits NO Bash permission allows in `.claude/settings.json`. All Bash commands require explicit user approval. This is intentional — anyone who clones this repo should review and approve commands individually.

--- a/scripts/check-docs-sync.sh
+++ b/scripts/check-docs-sync.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Docs-sync check (zero-cost, no LLM). Fails if agent code changed without docs.
+#
+# "Code" = scripts/ agents/ commands/  (the parts the README/CLAUDE/AGENTS/design describe).
+# "Docs" = README.md CLAUDE.md AGENTS.md docs/
+# Override: put [no-docs] in any commit message in the range when a change genuinely
+# needs no doc update (e.g. a bugfix). Then this passes.
+#
+# Usage:
+#   scripts/check-docs-sync.sh [base-ref]      # range mode (CI): <base>...HEAD   (default origin/main)
+#   scripts/check-docs-sync.sh --staged        # local mode: staged changes only
+
+set -uo pipefail
+
+CODE_RE='^(scripts/|agents/|commands/)'
+DOCS_RE='^(README\.md|CLAUDE\.md|AGENTS\.md|docs/)'
+
+if [ "${1:-}" = "--staged" ]; then
+  changed=$(git diff --cached --name-only)
+  msg="$(git diff --cached 2>/dev/null >/dev/null; echo "${COMMIT_MSG:-}")"  # message not known pre-commit; override via range only
+else
+  base="${1:-origin/main}"
+  changed=$(git diff --name-only "${base}...HEAD" 2>/dev/null)
+  msg=$(git log --format='%B' "${base}..HEAD" 2>/dev/null)
+fi
+
+code=$(printf '%s\n' "$changed" | grep -E "$CODE_RE" || true)
+docs=$(printf '%s\n' "$changed" | grep -E "$DOCS_RE" || true)
+override=$(printf '%s\n' "$msg" | grep -ci '\[no-docs\]' || true)
+
+if [ -n "$code" ] && [ -z "$docs" ] && [ "${override:-0}" -eq 0 ]; then
+  echo "::error::Code changed but no docs were updated."
+  echo "Update README.md / CLAUDE.md / AGENTS.md / docs/ to match — or add [no-docs] to a commit message if this genuinely needs none."
+  echo "Code files changed:"
+  printf '%s\n' "$code" | sed 's/^/  - /'
+  exit 1
+fi
+
+echo "docs-sync OK"
+exit 0


### PR DESCRIPTION
So docs can't silently lag code again. **Layered warn + override, zero token cost** (pure bash, no LLM, no secrets):

- `scripts/check-docs-sync.sh` — flags any change to `scripts/`/`agents/`/`commands/` with no `README`/`CLAUDE`/`AGENTS`/`docs` update. Override with **`[no-docs]`** in a commit message for genuine exceptions (e.g. a bugfix).
- `.github/workflows/docs-check.yml` — runs it on every PR (~seconds).
- `.claude/settings.json` — `PreToolUse` hook warns at commit time, same logic.
- `CLAUDE.md` documents the convention.

Dogfooded: this PR touches `scripts/` and updates `CLAUDE.md`, so its own check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)