### PR TITLE
ci: ShipIt runtime-smoke (+ advisory review) — P5a battle-test #2

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.shipit-gates/specialist-nudge.sh\"",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/.github/workflows/independent-review.yml
+++ b/.github/workflows/independent-review.yml
@@ -1,0 +1,164 @@
+name: Independent review (cross-model)
+
+# The author does not review its own work. This PR was authored with Claude; an
+# INDEPENDENT, non-Claude model reviews it before merge. Keyless: it calls GitHub
+# Models via the built-in GITHUB_TOKEN + `models: read` — no OpenAI key, no wallet.
+#
+# S6 v2 — PER-FILE review. Earlier the whole diff was sent in one call and truncated
+# at the GitHub Models request cap (~8k tokens), so on large PRs the reviewer SPECULATED
+# about unseen code and raised false MUST-FIX findings. Now each changed file is reviewed
+# in its OWN call, so every file is seen COMPLETE — no whole-diff truncation. (Only a
+# single file larger than the cap is truncated, and the prompt says so for that file.)
+#
+# Trade-off: per-file review can't see cross-file interactions. It is bounded to the
+# first MAX_FILES changed files; the rest are listed as not-reviewed (never silently
+# dropped). Cost: one small GitHub Models call per file (capped) — pennies per PR.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  models: read
+
+concurrency:
+  group: independent-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      REVIEW_MODEL: ${{ vars.SHIPIT_REVIEW_MODEL || 'openai/gpt-4.1' }}
+      # STRICT=true → fail on ANY [MUST-FIX] tag, not just the final VERDICT line.
+      # Default advisory (verdict line only); set repo var SHIPIT_REVIEW_STRICT=true to harden.
+      STRICT: ${{ vars.SHIPIT_REVIEW_STRICT || 'false' }}
+      MAX_FILES: "25"          # cost cap: never review more than this many files per PR
+      PER_FILE_CHARS: "24000"  # ~6k tokens; only a single oversized file is truncated
+      MIN_LINES: ${{ vars.SHIPIT_REVIEW_MIN_LINES || '10' }}  # size-gate: skip the review on trivial PRs
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Per-file independent review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set +e +u +o pipefail   # aggregator: handle every error manually; never spurious-fail (GH defaults to set -e)
+          base="origin/$BASE_REF"
+          git fetch -q origin "$BASE_REF" || true
+
+          # Conscious opt-out (like [no-docs]/[no-test]) — for a verified false positive.
+          if git log --format='%B' "$base..HEAD" 2>/dev/null | grep -qiF '[no-review]'; then
+            echo "[no-review] override present in a commit message — skipping independent review."
+            gh pr comment "$PR" --body "🔍 Independent review **skipped** via the \`[no-review]\` override." || true
+            exit 0
+          fi
+
+          # Size-gate: skip the (LLM-billed) review on docs-only / trivial PRs. Counts only
+          # code-file line churn (ignores .md/.mdx/.txt/.rst); numstat gives "-" for binaries → awk reads 0.
+          numstat="$(git diff --numstat "$base...HEAD" -- . ':(exclude)**/package-lock.json' ':(exclude)**/*.lock')"
+          codefiles="$(printf '%s\n' "$numstat" | awk 'NF && $3 !~ /\.(md|mdx|txt|rst)$/' | grep -c . || true)"
+          codelines="$(printf '%s\n' "$numstat" | awk '$3 !~ /\.(md|mdx|txt|rst)$/ {a+=$1; d+=$2} END{print a+d+0}')"
+          if [ "${codefiles:-0}" -eq 0 ]; then
+            gh pr comment "$PR" --body "🔍 Independent review **skipped** — docs-only change (no code files)." || true
+            exit 0
+          fi
+          if [ "${codelines:-0}" -lt "${MIN_LINES:-10}" ]; then
+            gh pr comment "$PR" --body "🔍 Independent review **skipped** — trivial change (${codelines} code line(s) < ${MIN_LINES})." || true
+            exit 0
+          fi
+
+          # Changed files, excluding lockfiles and binaries; capped at MAX_FILES.
+          mapfile -t ALL < <(git diff --name-only "$base...HEAD" -- . ':(exclude)**/package-lock.json' ':(exclude)**/*.lock')
+          FILES=("${ALL[@]:0:$MAX_FILES}")
+          SKIPPED=$(( ${#ALL[@]} - ${#FILES[@]} ))
+
+          SYS="You are an independent, adversarial code reviewer from a different model family than the author (Claude). You review ONE file's diff at a time. The diff you are given is the COMPLETE diff for that file unless a truncation note says otherwise — so do NOT speculate about code you cannot see, and never say a file 'may break' or 'is likely' buggy without pointing to a specific shown line. Reserve [MUST-FIX] for a concrete, demonstrable defect (real bug, security hole, data loss) you can cite a line for; design/style/process opinions are [NIT], never [MUST-FIX]. End with exactly one final line: 'VERDICT: MUST-FIX' if you listed a genuine [MUST-FIX] for this file, otherwise 'VERDICT: OK'."
+
+          overall_ok=1
+          : > findings.md
+          for f in "${FILES[@]}"; do
+            [ -n "$f" ] || continue
+            d="$(git diff "$base...HEAD" -- "$f")"
+            [ -z "$d" ] && continue   # no diff for this file (e.g. pure rename) — skip
+            note=""
+            if [ "${#d}" -gt "$PER_FILE_CHARS" ]; then
+              d="$(printf '%s' "$d" | head -c "$PER_FILE_CHARS")"
+              note=" (NOTE: this single file's diff was truncated at ${PER_FILE_CHARS} chars)"
+            fi
+            user="$(printf 'Review this file diff%s.\nFile: %s\n\n```diff\n%s\n```' "$note" "$f" "$d")"
+            body="$(jq -n --arg m "$REVIEW_MODEL" --arg s "$SYS" --arg u "$user" \
+              '{model:$m, max_tokens:700, messages:[{role:"system",content:$s},{role:"user",content:$u}]}')"
+            resp="$(curl -sS -X POST https://models.github.ai/inference/chat/completions \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/vnd.github+json" \
+              -d "$body" 2>/dev/null)"
+            content="$(printf '%s' "$resp" | jq -r '.choices[0].message.content // .error.message // "(no response)"' 2>/dev/null)"
+            {
+              echo "### \`$f\`"
+              echo "$content"
+              echo
+            } >> findings.md
+            # Trip ONLY on a standalone verdict line — not the string mid-prose (reviewing
+            # this very workflow, which contains verdict strings, would else false-trip).
+            # Explicit if-block so a no-match never bubbles a non-zero exit.
+            if printf '%s\n' "$content" | grep -qiE '^[[:space:]]*VERDICT:[[:space:]]*MUST-FIX[[:space:]]*$'; then
+              overall_ok=0
+            fi
+            # Strict mode: also trip on a [MUST-FIX] FINDING tag — one that LEADS a line
+            # (after list/heading markers), NOT a prose mention like "no [MUST-FIX] issues".
+            if [ "$STRICT" = "true" ] && printf '%s\n' "$content" | grep -qiE '^[[:space:]]*[-*#>0-9.)( ]*\[MUST-FIX\]'; then
+              overall_ok=0
+            fi
+          done
+
+          # --- cross-file pass: catch interactions a per-file review cannot see ---
+          if [ "${#FILES[@]}" -gt 1 ]; then
+            stat="$(git diff --stat "$base...HEAD" -- "${FILES[@]}" 2>/dev/null | head -c 4000)"
+            sigs="$(git diff "$base...HEAD" -- "${FILES[@]}" 2>/dev/null \
+              | grep -E '^[+-].*(function |def |class |export |const .+=|=>|sub |--[a-z-]+\)|^[+-][A-Za-z_]+\(\))' \
+              | head -c 16000)"
+            xsys="You are an independent reviewer given a CROSS-FILE summary of one PR (the file-change stat + the added/removed definition & signature lines across files). Identify ONLY concrete cross-file interaction risks: a changed signature/contract in one file that breaks a caller in another, a removed export/function still referenced elsewhere, an interface mismatch. Name the files. Do not repeat single-file style nits and do not speculate. Reserve [MUST-FIX] for a concrete cross-file break. End with exactly 'VERDICT: MUST-FIX' or 'VERDICT: OK'."
+            xuser="$(printf 'Change stat:\n%s\n\nDefinition/signature lines changed across files:\n%s' "$stat" "$sigs")"
+            xbody="$(jq -n --arg m "$REVIEW_MODEL" --arg s "$xsys" --arg u "$xuser" \
+              '{model:$m, max_tokens:600, messages:[{role:"system",content:$s},{role:"user",content:$u}]}')"
+            xresp="$(curl -sS -X POST https://models.github.ai/inference/chat/completions \
+              -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -H "Accept: application/vnd.github+json" \
+              -d "$xbody" 2>/dev/null)"
+            xcontent="$(printf '%s' "$xresp" | jq -r '.choices[0].message.content // .error.message // "(no response)"' 2>/dev/null)"
+            { echo "### 🔗 Cross-file interactions"; echo "$xcontent"; echo; } >> findings.md
+            if printf '%s\n' "$xcontent" | grep -qiE '^[[:space:]]*VERDICT:[[:space:]]*MUST-FIX[[:space:]]*$'; then overall_ok=0; fi
+            if [ "$STRICT" = "true" ] && printf '%s\n' "$xcontent" | grep -qiE '^[[:space:]]*[-*#>0-9.)( ]*\[MUST-FIX\]'; then overall_ok=0; fi
+          fi
+
+          {
+            echo "## 🔍 Independent cross-model review (per-file)"
+            echo "_Reviewer: \`$REVIEW_MODEL\` via GitHub Models — one call per changed file, so each file is seen complete (no whole-diff truncation). The author (Claude) does not review its own work._"
+            if [ "$STRICT" = "true" ]; then
+              echo "_Mode: **STRICT** — any \`[MUST-FIX]\` blocks the merge. Override a false positive with \`[no-review]\` in a commit message._"
+            else
+              echo "_Mode: **advisory** — findings are informational and do **NOT** block the merge. Set repo var \`SHIPIT_REVIEW_STRICT=true\` to make \`[MUST-FIX]\` block. (Runtime correctness is the runtime-smoke gate's job, not this diff review's.)_"
+            fi
+            [ "$SKIPPED" -gt 0 ] && echo && echo "> ⚠️ ${SKIPPED} file(s) beyond the ${MAX_FILES}-file cap were NOT reviewed — review them by hand."
+            echo
+            cat findings.md
+          } > comment.md
+          gh pr comment "$PR" --body-file comment.md || true
+
+          if [ "$overall_ok" -eq 0 ]; then
+            if [ "$STRICT" = "true" ]; then
+              echo "::error::STRICT: independent review found MUST-FIX — see the PR comment."
+              exit 1
+            fi
+            echo "::warning::Independent review flagged MUST-FIX (advisory — NOT blocking). See the PR comment."
+            exit 0
+          fi
+          echo "Independent review: OK across ${#FILES[@]} reviewed file(s)."

--- a/.github/workflows/runtime-smoke.yml
+++ b/.github/workflows/runtime-smoke.yml
@@ -1,0 +1,59 @@
+name: Runtime smoke-test
+
+# The gate the FocusBoard 504 taught us we needed: build + tests + deploy + review can ALL
+# be green while every route 504s at runtime. This fires BY ITSELF after a deploy — GitHub
+# emits `deployment_status` when Vercel (or any deploy integration) finishes, and
+# `environment_url` hands us the live URL with zero config (no token, no manual env). It hits
+# the DEPLOYED artifact: HTTP (curl) + the rendered UI (Playwright) + an optional E2E suite.
+#
+# Per-repo config: .shipit-gates/smoke.conf (SHIPIT_SMOKE_PATHS / _UI / _SELECTOR / _E2E_CMD).
+# No config → nothing to check → skips. The gate honours a [no-smoke] commit override.
+# NOTE: the installer rewrites the gate paths below into the repo's local gate dir.
+
+on: deployment_status
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-smoke:
+    # Only when a deploy actually succeeded, and only if we got a URL to hit.
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.deployment_status.deployment.sha }}
+
+      - name: Inspect smoke config
+        id: conf
+        run: |
+          if [ ! -f .shipit-gates/smoke.conf ]; then
+            echo "No .shipit-gates/smoke.conf — runtime-smoke has nothing to check. Skipping."
+            echo "skip=1" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "skip=0" >> "$GITHUB_OUTPUT"
+          if grep -qE '^[[:space:]]*SHIPIT_SMOKE_UI=1' .shipit-gates/smoke.conf; then
+            echo "ui=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "ui=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.conf.outputs.skip == '0' && steps.conf.outputs.ui == '1'
+        with:
+          node-version: "20"
+
+      - name: Install Playwright (UI tier only)
+        if: steps.conf.outputs.skip == '0' && steps.conf.outputs.ui == '1'
+        run: npm i playwright && npx playwright install --with-deps chromium
+
+      - name: Smoke-test the live deploy
+        if: steps.conf.outputs.skip == '0'
+        env:
+          SHIPIT_DEPLOY_URL: ${{ github.event.deployment_status.environment_url }}
+        run: |
+          set -a; . .shipit-gates/smoke.conf; set +a
+          bash .shipit-gates/runtime-smoke-test.sh

--- a/.shipit-gates/.version
+++ b/.shipit-gates/.version
@@ -1,0 +1,1 @@
+shipit-v4 gates v4.0.0 (targeted: runtime-smoke + specialist-nudge)

--- a/.shipit-gates/runtime-smoke-test.sh
+++ b/.shipit-gates/runtime-smoke-test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# runtime-smoke-test.sh — the gate the FocusBoard 504 taught us we needed.
+#
+# Green build + passing tests + successful deploy + passing code-review do NOT mean the
+# code works at runtime. (Proof: a Hono catch-all compiled, 661 tests passed, the build
+# + Vercel deploy went green, and the independent review passed — yet EVERY route 504'd
+# because a Web handler ran on the Node runtime. The 25 tests passed because they call
+# app.fetch() in-process, bypassing the deploy adapter.) AND a healthy API can sit behind
+# a broken UI (or vice-versa), so this gate hits BOTH: live HTTP endpoints and the real
+# rendered UI via Playwright — exactly the kind of pass a human does by hand.
+#
+# Deploy-conditional: only runs when a deploy URL is present (skips cleanly otherwise).
+# Override: [no-smoke] in a commit message (mirrors [no-test]/[no-docs]).
+#
+# Config:
+#   SHIPIT_DEPLOY_URL          deployed base URL (or pass as $1). No URL → skip.
+#   SHIPIT_SMOKE_PATHS         comma-separated API/page paths to curl (default "/").
+#                              Set this to CRITICAL routes — a SPA root often 200s while
+#                              /api/* 504s, the exact FocusBoard failure a root check misses.
+#   SHIPIT_SMOKE_UI            "1" → also drive the rendered UI with Playwright (ui-smoke.mjs).
+#   SHIPIT_SMOKE_UI_URL        page to load for the UI check (default = SHIPIT_DEPLOY_URL).
+#   SHIPIT_SMOKE_SELECTOR      selector that must render (default "body").
+#   SHIPIT_SMOKE_FAIL_ON_CONSOLE  "1" → fail on browser console errors (default: warn).
+#   SHIPIT_SMOKE_BASE          git base for the [no-smoke] scan (default origin/main).
+
+set -uo pipefail
+
+URL="${SHIPIT_DEPLOY_URL:-${1:-}}"
+if [ -z "$URL" ]; then
+  echo "runtime-smoke: no deploy URL (set SHIPIT_DEPLOY_URL or pass one) — skipping."
+  exit 0
+fi
+if git log --format='%B' "${SHIPIT_SMOKE_BASE:-origin/main}..HEAD" 2>/dev/null | grep -qiF '[no-smoke]'; then
+  echo "runtime-smoke: [no-smoke] override present — skipping."
+  exit 0
+fi
+
+fail=0
+
+# ── 1. HTTP smoke: every path must answer non-5xx, non-timeout ────────────────
+PATHS="${SHIPIT_SMOKE_PATHS:-/}"
+IFS=',' read -ra ARR <<< "$PATHS"
+for p in "${ARR[@]}"; do
+  [ -n "$p" ] || continue
+  full="${URL%/}${p}"
+  code="$(curl -s -o /dev/null --max-time 25 -w '%{http_code}' "$full" 2>/dev/null)"
+  # curl prints "000" on connect failure/timeout; normalise anything not a 3-digit code.
+  printf '%s' "$code" | grep -qE '^[0-9]{3}$' || code="000"
+  if [ "$code" = "000" ]; then
+    echo "::error::runtime-smoke: $full TIMED OUT / unreachable (the exact FocusBoard failure mode)"; fail=1
+  elif [ "$code" -ge 500 ]; then
+    echo "::error::runtime-smoke: $full → HTTP $code (5xx) — deployed artifact is broken"; fail=1
+  else
+    echo "runtime-smoke: $full → HTTP $code ✓"
+  fi
+done
+
+# ── 2. UI smoke: the real rendered page (Playwright) ──────────────────────────
+if [ "${SHIPIT_SMOKE_UI:-0}" = "1" ]; then
+  here="$(cd "$(dirname "$0")" && pwd)"
+  if command -v node >/dev/null 2>&1 && node -e "require.resolve('playwright')" >/dev/null 2>&1; then
+    SHIPIT_SMOKE_UI_URL="${SHIPIT_SMOKE_UI_URL:-$URL}" node "$here/ui-smoke.mjs" || fail=1
+  else
+    echo "::warning::runtime-smoke: UI check requested but Playwright isn't installed — run 'npm i -D playwright && npx playwright install chromium'. Skipping the UI smoke."
+  fi
+fi
+
+# ── 3. Full E2E suite (optional): the project's Cypress / Playwright Test / Cucumber ──
+# This gate is the always-on FLOOR (liveness + render). Your real user-FLOW tests live
+# in a proper E2E suite — point this at it and ShipIt runs it against the DEPLOYED
+# artifact. The deploy URL is exported as both SHIPIT_DEPLOY_URL and BASE_URL so the
+# suite can target it (Cypress baseUrl, Playwright baseURL, a BASE_URL your steps read).
+#   e.g.  SHIPIT_SMOKE_E2E_CMD="npx playwright test"
+#         SHIPIT_SMOKE_E2E_CMD="npx cypress run --config baseUrl=$SHIPIT_DEPLOY_URL"
+#         SHIPIT_SMOKE_E2E_CMD="npx cucumber-js"
+if [ -n "${SHIPIT_SMOKE_E2E_CMD:-}" ]; then
+  echo "runtime-smoke: running E2E suite → $SHIPIT_SMOKE_E2E_CMD"
+  if SHIPIT_DEPLOY_URL="$URL" BASE_URL="$URL" bash -c "$SHIPIT_SMOKE_E2E_CMD"; then
+    echo "runtime-smoke: E2E suite passed ✓"
+  else
+    echo "::error::runtime-smoke: E2E suite FAILED against $URL"; fail=1
+  fi
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "runtime-smoke OK"
+  exit 0
+fi
+echo "::error::runtime-smoke FAILED — the deployed artifact is broken at runtime despite green CI."
+exit 1

--- a/.shipit-gates/smoke.conf
+++ b/.shipit-gates/smoke.conf
@@ -1,0 +1,9 @@
+# ShipIt runtime smoke-test config — read by runtime-smoke CI. Sourced as bash.
+# ProveIt = a Next.js app (in web/) on proveit.tools. All /api routes are POST-only and the
+# LLM calls live ONLY in the POST handlers — so a smoke GET returns 405 (function alive),
+# which is NOT a 5xx (gate passes) and NEVER triggers a billable LLM call. Verified live:
+#   / → 200 · /api/waitlist GET → 405 · /api/chat GET → 405 (no LLM invoked).
+SHIPIT_SMOKE_PATHS=/,/api/waitlist
+SHIPIT_SMOKE_UI=1
+SHIPIT_SMOKE_SELECTOR=main
+SHIPIT_SMOKE_E2E_CMD=

--- a/.shipit-gates/specialist-nudge.sh
+++ b/.shipit-gates/specialist-nudge.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# specialist-nudge.sh — PreToolUse(Bash) reminder, NON-blocking.
+#
+# On a `git commit`, inspects the STAGED diff and, if it touches an architectural or a UI
+# surface, nudges you to summon the matching @agent before shipping. It never blocks
+# (exit 0) — like docs-sync-reminder.sh, it's the early prompt, not the wall.
+#
+# The agents ship WITH the plugin (agents/architect.md, agents/designer.md), so the nudge
+# always points at a real, installed specialist. The single highest-value output of the
+# first wild run was an ad-hoc specialist summon (the architect catching a half-aspirational
+# API boundary) — this fires that pattern by itself instead of leaving it to memory.
+#
+# NOTE: the architect's biggest win is at PLAN time (summon before building), not just here
+# at commit time. This commit-time nudge is the backstop for when that didn't happen.
+#
+# Installed per-repo by install-gates.sh (copied into .shipit-gates/, wired into
+# .claude/settings.json PreToolUse).
+set -uo pipefail
+command -v jq >/dev/null 2>&1 || exit 0
+cmd="$(cat | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+printf '%s' "$cmd" | grep -q 'git commit' || exit 0
+
+staged="$(git diff --cached --name-only 2>/dev/null || true)"
+[ -n "$staged" ] || exit 0
+
+# Architectural surfaces: migrations, raw SQL, schema/data-model files, the API boundary.
+arch="$(printf '%s\n' "$staged" | grep -Ei '(^|/)migrations/|\.sql$|(^|/)schema\.|(^|/)api/' || true)"
+# A new dependency line added to a staged package.json (added `"name": "version"`).
+if printf '%s\n' "$staged" | grep -q 'package\.json$'; then
+  if git diff --cached -- '*package.json' 2>/dev/null \
+       | grep -Eq '^\+[[:space:]]+"[^"]+"[[:space:]]*:[[:space:]]*"[^"]+"'; then
+    arch="${arch}"$'\n'"package.json (new dependency)"
+  fi
+fi
+# UI surfaces: components, TSX/JSX, CSS/SCSS (Tailwind). NOTE: we deliberately do NOT match a
+# bare `pages/`/`app/` directory — in a Next.js App Router repo, API routes ALSO live under
+# `app/` (e.g. app/api/x/route.ts), so a dir match fires @designer on pure API routes (a real
+# false positive found battle-testing ProveIt). A UI page is a `.tsx`/`.jsx` (caught below); a
+# `route.ts` is an API file → it stays @architect-only via the `api/` match above.
+ui="$(printf '%s\n' "$staged" | grep -Ei '(^|/)components/|\.(tsx|jsx)$|\.(css|scss)$' || true)"
+
+if [ -n "$arch" ]; then
+  echo "specialist nudge: staged changes touch an architectural surface (migrations / *.sql / api/ / new deps) — summon @architect to review the design before shipping (best done at PLAN time, not just pre-merge)." >&2
+fi
+if [ -n "$ui" ]; then
+  echo "specialist nudge: staged changes touch a UI surface (components / *.tsx / *.css) — summon @designer to review the user-facing change before shipping." >&2
+fi
+exit 0

--- a/.shipit-gates/ui-smoke.mjs
+++ b/.shipit-gates/ui-smoke.mjs
@@ -1,0 +1,56 @@
+/**
+ * ui-smoke.mjs — the UI half of the runtime smoke gate.
+ *
+ * Loads the DEPLOYED page in a real browser (Playwright) and asserts it actually
+ * RENDERS — not just that the server returned 200. Catches the failures a curl can't:
+ * a white screen, an uncaught render error, a missing root element, a 5xx behind the
+ * page. Console errors are reported (warn) and can hard-fail with SHIPIT_SMOKE_FAIL_ON_CONSOLE=1.
+ *
+ * Requires `playwright` in the project (`npm i -D playwright && npx playwright install chromium`).
+ * Env: SHIPIT_SMOKE_UI_URL (required), SHIPIT_SMOKE_SELECTOR (default "body"),
+ *      SHIPIT_SMOKE_FAIL_ON_CONSOLE ("1" to fail on console errors).
+ */
+import { chromium } from "playwright";
+
+const url = process.env.SHIPIT_SMOKE_UI_URL;
+const selector = process.env.SHIPIT_SMOKE_SELECTOR || "body";
+const failOnConsole = process.env.SHIPIT_SMOKE_FAIL_ON_CONSOLE === "1";
+
+if (!url) {
+  console.log("ui-smoke: no SHIPIT_SMOKE_UI_URL — skipping.");
+  process.exit(0);
+}
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+const consoleErrors = [];
+const pageErrors = [];
+page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text()); });
+page.on("pageerror", (e) => pageErrors.push(e.message));
+
+let ok = true;
+try {
+  const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  if (resp && resp.status() >= 500) {
+    console.error(`::error::ui-smoke: ${url} → HTTP ${resp.status()}`);
+    ok = false;
+  }
+  await page.waitForSelector(selector, { state: "attached", timeout: 15000 });
+  console.log(`ui-smoke: ${url} rendered (selector '${selector}' present) ✓`);
+} catch (e) {
+  console.error(`::error::ui-smoke: ${url} did not render — ${e.message}`);
+  ok = false;
+}
+
+if (pageErrors.length) {
+  console.error(`::error::ui-smoke: ${pageErrors.length} uncaught page error(s): ${pageErrors.slice(0, 5).join(" | ")}`);
+  ok = false;
+}
+if (consoleErrors.length) {
+  const msg = `ui-smoke: ${consoleErrors.length} browser console error(s): ${consoleErrors.slice(0, 5).join(" | ")}`;
+  if (failOnConsole) { console.error(`::error::${msg}`); ok = false; }
+  else { console.warn(`::warning::${msg}`); }
+}
+
+await browser.close();
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
Installs ShipIt V4's **runtime-smoke** gate on ProveIt — the **2nd real customer** (P5a). 

**Targeted install, not the full installer.** ProveIt is a monorepo (Next.js app in `web/`) with its own monorepo-aware `ci.yml` + `docs-check.yml` — both **preserved**. We add only what ProveIt lacks: `runtime-smoke` (live-artifact check), plus the **advisory** cross-model review (to gather P5d data) and the specialist-nudge (P3).

### smoke.conf — cost-safe by construction
All `/api` routes are **POST-only** and the LLM calls live **only** in the POST handlers. A smoke **GET** returns **405** (function alive, not 5xx → passes) and **never triggers a billable LLM call**.
| Setting | Value |
|---|---|
| `SHIPIT_SMOKE_PATHS` | `/,/api/waitlist` |
| `SHIPIT_SMOKE_UI` | `1` |
| `SHIPIT_SMOKE_SELECTOR` | `main` |

### Verified against live `proveit.tools`
```
/             → 200
/api/waitlist → 405 (function alive, no LLM)
ui-smoke      → 'main' rendered
```

### Findings fed back to P5a
- **`install-gates.sh` assumes a root single-package repo** — doesn't fit a monorepo (hence the targeted install). Worth a monorepo mode.
- Battle-testing already caught + fixed an App Router false positive in the nudge (shipit-v4 PR #16): it fired `@designer` on API routes under `app/`. ProveIt carries the fixed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)