### PR TITLE
ci: refresh .shipit-gates v4.0.0 — ui-smoke 401-skip fix

### DIFF
--- a/.shipit-gates/.version
+++ b/.shipit-gates/.version
@@ -1,1 +1,1 @@
-shipit-v4 gates v4.0.0 (targeted: runtime-smoke + specialist-nudge)
+shipit-v4 gates v4.0.0

--- a/.shipit-gates/runtime-smoke-test.sh
+++ b/.shipit-gates/runtime-smoke-test.sh
@@ -38,22 +38,69 @@ fi
 fail=0
 
 # ── 1. HTTP smoke: every path must answer non-5xx, non-timeout ────────────────
-PATHS="${SHIPIT_SMOKE_PATHS:-/}"
-IFS=',' read -ra ARR <<< "$PATHS"
-for p in "${ARR[@]}"; do
-  [ -n "$p" ] || continue
+# A path may pin an EXACT expected status with "=NNN" (e.g. /api/capture=401,
+# /api/health/deep=200). Without "=", any non-5xx passes. Exact pins catch routing
+# regressions that hide behind "not a 5xx" — e.g. Vercel platform-404ing a path
+# that should reach the router (FocusBoard's multi-segment [...path].ts bug).
+http_check() {  # $1=path-spec  $2=auth-header-or-empty
+  local spec="$1" auth="$2" p want full code
+  p="${spec%%=*}"; want=""
+  [ "$spec" != "$p" ] && want="${spec#*=}"
   full="${URL%/}${p}"
-  code="$(curl -s -o /dev/null --max-time 25 -w '%{http_code}' "$full" 2>/dev/null)"
+  if [ -n "$auth" ]; then
+    code="$(curl -s -o /dev/null --max-time 25 -w '%{http_code}' -H "$auth" "$full" 2>/dev/null)"
+  else
+    code="$(curl -s -o /dev/null --max-time 25 -w '%{http_code}' "$full" 2>/dev/null)"
+  fi
   # curl prints "000" on connect failure/timeout; normalise anything not a 3-digit code.
   printf '%s' "$code" | grep -qE '^[0-9]{3}$' || code="000"
   if [ "$code" = "000" ]; then
     echo "::error::runtime-smoke: $full TIMED OUT / unreachable (the exact FocusBoard failure mode)"; fail=1
+  elif [ -n "$want" ] && [ "$code" != "$want" ]; then
+    echo "::error::runtime-smoke: $full → HTTP $code, expected $want — routing/auth regression on the deployed artifact"; fail=1
   elif [ "$code" -ge 500 ]; then
     echo "::error::runtime-smoke: $full → HTTP $code (5xx) — deployed artifact is broken"; fail=1
   else
     echo "runtime-smoke: $full → HTTP $code ✓"
   fi
+}
+
+PATHS="${SHIPIT_SMOKE_PATHS:-/}"
+IFS=',' read -ra ARR <<< "$PATHS"
+for spec in "${ARR[@]}"; do
+  [ -n "$spec" ] || continue
+  http_check "$spec" ""
 done
+
+# ── 1b. Authenticated tier (optional): data correctness, not just liveness ────
+# Tiers 1+2 prove liveness/routing/auth — they CANNOT see wrong-rows-returned-to-
+# an-authed-caller (FocusBoard's inbox status-filter bug passed every unauth gate).
+# When a low-privilege test credential is present as a CI secret
+# (SHIPIT_SMOKE_AUTH_TOKEN), this tier runs; without it, it skips with a note.
+#   SHIPIT_SMOKE_AUTH_PATHS  same path[=NNN] syntax, curled WITH the Bearer token.
+#   SHIPIT_SMOKE_AUTH_CMD    a project round-trip script (create → list-shows-it →
+#                            delete), run with SHIPIT_DEPLOY_URL + the token in env.
+#                            Reference implementation: FocusBoard's capture →
+#                            inbox → dismiss loop in its .shipit-gates copy.
+if [ -n "${SHIPIT_SMOKE_AUTH_TOKEN:-}" ]; then
+  if [ -n "${SHIPIT_SMOKE_AUTH_PATHS:-}" ]; then
+    IFS=',' read -ra AARR <<< "$SHIPIT_SMOKE_AUTH_PATHS"
+    for spec in "${AARR[@]}"; do
+      [ -n "$spec" ] || continue
+      http_check "$spec" "Authorization: Bearer $SHIPIT_SMOKE_AUTH_TOKEN"
+    done
+  fi
+  if [ -n "${SHIPIT_SMOKE_AUTH_CMD:-}" ]; then
+    echo "runtime-smoke[authed]: running round-trip → $SHIPIT_SMOKE_AUTH_CMD"
+    if SHIPIT_DEPLOY_URL="$URL" bash -c "$SHIPIT_SMOKE_AUTH_CMD"; then
+      echo "runtime-smoke[authed]: round-trip ✓"
+    else
+      echo "::error::runtime-smoke[authed]: round-trip FAILED — wrong data to an authed caller on the deployed artifact"; fail=1
+    fi
+  fi
+else
+  echo "runtime-smoke: no SHIPIT_SMOKE_AUTH_TOKEN — authed tier skipped (liveness only; this tier cannot see data correctness)."
+fi
 
 # ── 2. UI smoke: the real rendered page (Playwright) ──────────────────────────
 if [ "${SHIPIT_SMOKE_UI:-0}" = "1" ]; then

--- a/.shipit-gates/specialist-nudge.sh
+++ b/.shipit-gates/specialist-nudge.sh
@@ -10,8 +10,9 @@
 # first wild run was an ad-hoc specialist summon (the architect catching a half-aspirational
 # API boundary) — this fires that pattern by itself instead of leaving it to memory.
 #
-# NOTE: the architect's biggest win is at PLAN time (summon before building), not just here
-# at commit time. This commit-time nudge is the backstop for when that didn't happen.
+# The architect's biggest win is at PLAN time (summon before building). So this fires on a
+# staged plan/PRD/architecture doc with a PLAN-TIME message (P5e) — and still on staged code
+# surfaces at commit time as the backstop for when that didn't happen.
 #
 # Installed per-repo by install-gates.sh (copied into .shipit-gates/, wired into
 # .claude/settings.json PreToolUse).
@@ -22,6 +23,12 @@ printf '%s' "$cmd" | grep -q 'git commit' || exit 0
 
 staged="$(git diff --cached --name-only 2>/dev/null || true)"
 [ -n "$staged" ] || exit 0
+
+# PLAN-TIME surface (the architect's HIGHEST-value moment, P5e): a plan / PRD / architecture
+# doc is staged → you're designing, not yet building. Summoning @architect here prevents a bad
+# build, which is far higher ROI than catching it at commit time. Matches docs/plans/*.md,
+# ARCHITECTURE.md(x), and *prd*.md(x).
+plan="$(printf '%s\n' "$staged" | grep -Ei '(^|/)docs/plans/.*\.(md|mdx)$|(^|/)architecture\.(md|mdx)$|(^|/)[^/]*prd[^/]*\.(md|mdx)$' || true)"
 
 # Architectural surfaces: migrations, raw SQL, schema/data-model files, the API boundary.
 arch="$(printf '%s\n' "$staged" | grep -Ei '(^|/)migrations/|\.sql$|(^|/)schema\.|(^|/)api/' || true)"
@@ -39,7 +46,9 @@ fi
 # `route.ts` is an API file → it stays @architect-only via the `api/` match above.
 ui="$(printf '%s\n' "$staged" | grep -Ei '(^|/)components/|\.(tsx|jsx)$|\.(css|scss)$' || true)"
 
-if [ -n "$arch" ]; then
+if [ -n "$plan" ]; then
+  echo "specialist nudge (PLAN TIME): a plan / PRD / architecture doc is staged — summon @architect to review the DESIGN now, before building. This is the architect's highest-value moment (the wild run's best ROI): catching a bad design here prevents the whole bad build." >&2
+elif [ -n "$arch" ]; then
   echo "specialist nudge: staged changes touch an architectural surface (migrations / *.sql / api/ / new deps) — summon @architect to review the design before shipping (best done at PLAN time, not just pre-merge)." >&2
 fi
 if [ -n "$ui" ]; then

--- a/.shipit-gates/ui-smoke.mjs
+++ b/.shipit-gates/ui-smoke.mjs
@@ -31,12 +31,24 @@ page.on("pageerror", (e) => pageErrors.push(e.message));
 let ok = true;
 try {
   const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
-  if (resp && resp.status() >= 500) {
-    console.error(`::error::ui-smoke: ${url} → HTTP ${resp.status()}`);
-    ok = false;
+  const status = resp ? resp.status() : 0;
+  if (status === 401 || status === 403) {
+    // Auth-gated (e.g. Vercel deployment protection on a preview). The page that loads is the
+    // protection/login screen, NOT the app — asserting a selector here would FALSE-PASS on it.
+    // Skip the render check honestly rather than claim a render; the public PRODUCTION deploy
+    // (deployment_status fires there too) is where the UI is actually verified.
+    console.warn(`::warning::ui-smoke: ${url} → HTTP ${status} (auth-gated — likely deployment protection). The protection screen is not the app, so the render assertion is SKIPPED here, not false-passed. The production deploy verifies the UI.`);
+    await browser.close();
+    process.exit(0);
   }
-  await page.waitForSelector(selector, { state: "attached", timeout: 15000 });
-  console.log(`ui-smoke: ${url} rendered (selector '${selector}' present) ✓`);
+  if (status >= 400) {
+    // 404/4xx/5xx: the page did not load — never claim it "rendered".
+    console.error(`::error::ui-smoke: ${url} → HTTP ${status} — page did not load`);
+    ok = false;
+  } else {
+    await page.waitForSelector(selector, { state: "attached", timeout: 15000 });
+    console.log(`ui-smoke: ${url} rendered (selector '${selector}' present) ✓`);
+  }
 } catch (e) {
   console.error(`::error::ui-smoke: ${url} did not render — ${e.message}`);
   ok = false;


### PR DESCRIPTION
Propagates the runtime-smoke UI-tier fix via `install-gates.sh --update` (refresh-existing-only — ProveIt's targeted gate set stays as-is). The UI tier now **skips honestly on a 401** protected preview instead of false-passing on the Vercel protection screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)