### PR TITLE
fix(docs-check): cover the web app, not just the plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r \".tool_input.command // empty\"); if printf \"%s\" \"$cmd\" | grep -q \"git commit\"; then s=$(git diff --cached --name-only 2>/dev/null); if printf \"%s\" \"$s\" | grep -qE \"^(scripts/|agents/|commands/)\" && ! printf \"%s\" \"$s\" | grep -qE \"^(README\\.md|CLAUDE\\.md|AGENTS\\.md|docs/)\"; then echo \"docs-sync reminder: code is staged with no docs (README/CLAUDE/AGENTS/docs). Update them, or put [no-docs] in the commit message if none are needed.\"; fi; fi",
+            "command": "cmd=$(jq -r \".tool_input.command // empty\"); if printf \"%s\" \"$cmd\" | grep -q \"git commit\"; then s=$(git diff --cached --name-only 2>/dev/null); if printf \"%s\" \"$s\" | grep -qE \"^(scripts/|agents/|commands/|web/src/)\" && ! printf \"%s\" \"$s\" | grep -qE \"^(README\\.md|CLAUDE\\.md|AGENTS\\.md|docs/|web/README\\.md)\"; then echo \"docs-sync reminder: code is staged with no docs (README/CLAUDE/AGENTS/docs/web/README). Update them, or put [no-docs] in the commit message if none are needed.\"; fi; fi",
             "timeout": 5
           }
         ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Research phases are delegated to Sonnet subagents for speed.
 
 ## Keeping docs in sync with code — enforced
 
-When you change `scripts/`, `agents/`, or `commands/`, update the docs that describe them: `README.md`, `CLAUDE.md`, `AGENTS.md`, and `docs/` (including the directory trees). This is **enforced**, not advisory:
+When you change `scripts/`, `agents/`, or `commands/` (the plugin) **or `web/src/` (the web app)**, update the docs that describe them: `README.md`, `CLAUDE.md`, `AGENTS.md`, `docs/`, or `web/README.md` (including the directory trees). This is **enforced**, not advisory:
 
 - **CI gate** — `.github/workflows/docs-check.yml` flags any PR where code changed without a doc update (pure bash, no LLM, no token cost).
 - **In-session reminder** — a `PreToolUse` hook in `.claude/settings.json` warns at commit time if code is staged without docs.

--- a/scripts/check-docs-sync.sh
+++ b/scripts/check-docs-sync.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Docs-sync check (zero-cost, no LLM). Fails if agent code changed without docs.
 #
-# "Code" = scripts/ agents/ commands/  (the parts the README/CLAUDE/AGENTS/design describe).
-# "Docs" = README.md CLAUDE.md AGENTS.md docs/
+# "Code" = scripts/ agents/ commands/ (the ProveIt PLUGIN) + web/src/ (the web APP). The
+#   original CODE_RE covered only the plugin dirs, so a web-app PR matched nothing and passed
+#   green every time — docs-sync was a silent no-op on the actual product.
+# "Docs" = README.md CLAUDE.md AGENTS.md docs/ web/README.md
 # Override: put [no-docs] in any commit message in the range when a change genuinely
 # needs no doc update (e.g. a bugfix). Then this passes.
 #
@@ -12,8 +14,8 @@
 
 set -uo pipefail
 
-CODE_RE='^(scripts/|agents/|commands/)'
-DOCS_RE='^(README\.md|CLAUDE\.md|AGENTS\.md|docs/)'
+CODE_RE='^(scripts/|agents/|commands/|web/src/)'
+DOCS_RE='^(README\.md|CLAUDE\.md|AGENTS\.md|docs/|web/README\.md)'
 
 if [ "${1:-}" = "--staged" ]; then
   changed=$(git diff --cached --name-only)
@@ -30,7 +32,7 @@ override=$(printf '%s\n' "$msg" | grep -ci '\[no-docs\]' || true)
 
 if [ -n "$code" ] && [ -z "$docs" ] && [ "${override:-0}" -eq 0 ]; then
   echo "::error::Code changed but no docs were updated."
-  echo "Update README.md / CLAUDE.md / AGENTS.md / docs/ to match — or add [no-docs] to a commit message if this genuinely needs none."
+  echo "Update README.md / CLAUDE.md / AGENTS.md / docs/ / web/README.md to match — or add [no-docs] to a commit message if this genuinely needs none."
   echo "Code files changed:"
   printf '%s\n' "$code" | sed 's/^/  - /'
   exit 1


### PR DESCRIPTION
ProveIt's docs-sync `CODE_RE` only matched `scripts/|agents/|commands/` (the plugin), so a **web-app PR (`web/src/`) matched nothing and passed green every time** — a silent no-op on the actual product. Same false-confidence shape just fixed in ShipIt; ProveIt has its own copy of the script.

- `CODE_RE` now includes `web/src/`; `DOCS_RE` includes `web/README.md`
- the `.claude/settings.json` commit-reminder hook broadened to match
- `CLAUDE.md` 'keeping docs in sync' updated to name `web/src` + `web/README`

Verified: a `web/src`-only change now **fails** (was a silent pass); `web/src` + a doc **passes**; plugin changes still enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)