### PR TITLE
fix(docs): Phase 0 codebase hardening — docs-sync, architecture, settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r \".tool_input.command // empty\"); if printf \"%s\" \"$cmd\" | grep -q \"git commit\"; then s=$(git diff --cached --name-only 2>/dev/null); if printf \"%s\" \"$s\" | grep -qE \"^(scripts/|agents/|commands/|web/src/)\" && ! printf \"%s\" \"$s\" | grep -qE \"^(README\\.md|CLAUDE\\.md|AGENTS\\.md|docs/|web/README\\.md)\"; then echo \"docs-sync reminder: code is staged with no docs (README/CLAUDE/AGENTS/docs/web/README). Update them, or put [no-docs] in the commit message if none are needed.\"; fi; fi",
+            "command": "cmd=$(jq -r \".tool_input.command // empty\"); if printf \"%s\" \"$cmd\" | grep -q \"git commit\"; then s=$(git diff --cached --name-only 2>/dev/null); if printf \"%s\" \"$s\" | grep -qE \"^(scripts/|agents/|commands/|web/src/|studio/src/|packages/)\" && ! printf \"%s\" \"$s\" | grep -qE \"^(README\\.md|CLAUDE\\.md|AGENTS\\.md|docs/|web/README\\.md|studio/README\\.md)\"; then echo \"docs-sync reminder: code is staged with no docs (README/CLAUDE/AGENTS/docs/web/README/studio/README). Update them, or put [no-docs] in the commit message if none are needed.\"; fi; fi",
             "timeout": 5
           }
         ]

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -7,7 +7,7 @@ name: Docs sync check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/proveit-studio]
 
 permissions:
   contents: read

--- a/.github/workflows/independent-review.yml
+++ b/.github/workflows/independent-review.yml
@@ -16,7 +16,7 @@ name: Independent review (cross-model)
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/proveit-studio]
 
 permissions:
   contents: read

--- a/scripts/check-docs-sync.sh
+++ b/scripts/check-docs-sync.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # Docs-sync check (zero-cost, no LLM). Fails if agent code changed without docs.
 #
-# "Code" = scripts/ agents/ commands/ (the ProveIt PLUGIN) + web/src/ (the web APP). The
-#   original CODE_RE covered only the plugin dirs, so a web-app PR matched nothing and passed
-#   green every time — docs-sync was a silent no-op on the actual product.
-# "Docs" = README.md CLAUDE.md AGENTS.md docs/ web/README.md
+# "Code" = scripts/ agents/ commands/ (plugin) + web/src/ (web app) + studio/src/ (Studio)
+#   + packages/ (shared core). AGENTS.md requires doc updates for all of these.
+# "Docs" = README.md CLAUDE.md AGENTS.md docs/ web/README.md studio/README.md
 # Override: put [no-docs] in any commit message in the range when a change genuinely
 # needs no doc update (e.g. a bugfix). Then this passes.
 #
@@ -14,8 +13,8 @@
 
 set -uo pipefail
 
-CODE_RE='^(scripts/|agents/|commands/|web/src/)'
-DOCS_RE='^(README\.md|CLAUDE\.md|AGENTS\.md|docs/|web/README\.md)'
+CODE_RE='^(scripts/|agents/|commands/|web/src/|studio/src/|packages/)'
+DOCS_RE='^(README\.md|CLAUDE\.md|AGENTS\.md|docs/|web/README\.md|studio/README\.md)'
 
 if [ "${1:-}" = "--staged" ]; then
   changed=$(git diff --cached --name-only)
@@ -32,7 +31,7 @@ override=$(printf '%s\n' "$msg" | grep -ci '\[no-docs\]' || true)
 
 if [ -n "$code" ] && [ -z "$docs" ] && [ "${override:-0}" -eq 0 ]; then
   echo "::error::Code changed but no docs were updated."
-  echo "Update README.md / CLAUDE.md / AGENTS.md / docs/ / web/README.md to match — or add [no-docs] to a commit message if this genuinely needs none."
+  echo "Update README.md / CLAUDE.md / AGENTS.md / docs/ / web/README.md / studio/README.md to match — or add [no-docs] to a commit message if this genuinely needs none."
   echo "Code files changed:"
   printf '%s\n' "$code" | sed 's/^/  - /'
   exit 1

--- a/web/.claude/settings.json
+++ b/web/.claude/settings.json
@@ -1,9 +1,4 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash"
-    ]
-  },
   "hooks": {
     "PostToolUse": [
       {
@@ -11,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/clairedonald/proveit/web && npx tsc --noEmit 2>&1 | head -20 || true",
+            "command": "cd \"$(git rev-parse --show-toplevel)/web\" && npx tsc --noEmit 2>&1 | head -20 || true",
             "description": "TypeScript check after file write (advisory)"
           }
         ]

--- a/web/ARCHITECTURE.md
+++ b/web/ARCHITECTURE.md
@@ -913,11 +913,11 @@ See `web/.env.example` for the full list including optional vars (PostHog, Resen
 **Rejected:** Server-side session tracking.
 **Rationale:** Stateless server for chat is simpler and cheaper. The client is the source of truth for session state (backed by localStorage). The server only needs the current state to inject into the system prompt — it does not need server-side session history. Transactional data (orders, waitlist) is persisted separately in Supabase.
 
-### Decision 6: Markdown download, no Gamma
+### Decision 6: Markdown download for free tier; deck via paid fulfilment (no in-session Gamma)
 
-**Chosen:** Client-side markdown generation and file download.
-**Rejected:** Gamma MCP integration for web MVP.
-**Rationale:** Gamma integration requires MCP server infrastructure not present in a Next.js web app. The Claude Code plugin version uses Gamma because MCP tools are available in that runtime. For the web MVP, a markdown download provides the same reference artifact with zero infrastructure. Gamma can be added in a later version via a separate API if the Gamma HTTP API becomes available.
+**Chosen:** Client-side markdown generation and file download for all Full Validation completions. Paid bundle orders receive a branded deck HTML artefact via the automated fulfilment pipeline, stored in Supabase Storage and served at `GET /deck/[orderId]`.
+**Rejected:** In-browser Gamma MCP integration for the free web flow.
+**Rationale:** Gamma MCP requires Claude Code runtime infrastructure not present in a Next.js web app. The free tier gets a markdown download with zero extra infrastructure. The paid path runs fulfilment server-side after Stripe checkout (webhook → `fulfilment.ts`), which generates and stores the deck out of band — not live in the chat session. The Claude Code plugin still uses Gamma in-session because MCP tools are available there.
 
 ### Decision 7: `server-only` package for Anthropic client
 

--- a/web/ARCHITECTURE.md
+++ b/web/ARCHITECTURE.md
@@ -1,27 +1,27 @@
 # ProveIt Web — Architecture Specification
 
-**Version:** 1.0
-**Date:** 2026-02-22
+**Version:** 1.1  
+**Date:** 2026-02-22 (§1 updated 2026-08-02)  
 **Status:** Approved for build
 
 ---
 
 ## 1. System Overview
 
-ProveIt Web is a public Next.js 15 App Router application. It exposes the ProveIt validation workflow — currently a Claude Code plugin — as a web UI accessible without any tooling setup. There is no authentication, no database, and no user accounts. All state lives in the browser's localStorage. Anthropic API calls are made exclusively from server-side Route Handlers.
+ProveIt Web is a public Next.js 15 App Router application. It exposes the ProveIt validation workflow — currently a Claude Code plugin — as a web UI accessible without any tooling setup. There is **no user authentication** and **no cross-device session sync** — Full Validation state lives in the browser's localStorage. **Server-side persistence** uses Supabase for transactional data (waitlist signups, paid orders, Wizard-of-Oz purchase intent) and deck storage; Stripe handles the one-off paid bundle checkout. Anthropic API calls are made exclusively from server-side Route Handlers.
 
 **Two modes, one product:**
 
 - **Fast Check** — Single-shot: user pastes an idea, receives three streamed assumption verdict cards. No conversation. Target completion: under 90 seconds.
-- **Full Validation** — Conversational: chat interface drives a multi-phase discovery loop, delegates to Anthropic's native web search for research, returns scored results with a downloadable markdown summary.
+- **Full Validation** — Conversational: chat interface drives a multi-phase discovery loop, delegates to Anthropic's native web search for research, returns scored results with a downloadable markdown summary. On completion, users can optionally purchase a full validation bundle via Stripe.
 
-**What this is not:** No auth, no database, no persistence across devices, no Gamma deck generation (cut for web MVP), no multi-user sessions.
+**What this is not:** No user accounts or login, no persistence across devices for chat sessions, no in-browser Gamma deck generation (paid orders receive a deck via fulfilment pipeline), no multi-user sessions.
 
 ---
 
 ## 2. Component Diagram
 
-Reflects actual `src/` tree as of 2026-05-10. Updated after the security/typography pass, the FastPageContent refactor, and the v3.5 Claude Design integration (FullBundlePointer added).
+Reflects actual `src/` tree as of 2026-08-02. Updated after Supabase/Stripe integration and the v3.5 Claude Design integration (FullBundlePointer added).
 
 ```
 Browser
@@ -37,18 +37,20 @@ Browser
 │           ├── AssumptionCard (Client)    — individual verdict card (x3)
 │           └── StreamingIndicator (Client) — live typing animation
 │
-└── /validate (Full Validation — src/app/validate/page.tsx, Server shell)
-    └── ChatInterface (Client)              — orchestrates session; idea input form + chat UI
-        ├── MessageList (Client)            — renders conversation history
-        │   ├── UserMessage (Client)
-        │   └── AssistantMessage (Client)
-        │       └── StreamingText (Client) — token-level stream render
-        ├── ChatInput (Client)              — text input + send / stop button
-        ├── PhaseIndicator (Client)         — Brain Dump / Discovery / Research / Findings / Complete
-        ├── SearchingIndicator (Client)     — search-query log + dots during research phase
-        ├── ScorePanel (Client)             — live Desirability/Viability/Feasibility + kill signals
-        ├── DownloadButton (Client)         — generates + downloads discovery.md (with inline error)
-        └── FullBundlePointer (Client)      — shown on complete; points to /proveit CLI for full 7-artefact bundle
+├── /validate (Full Validation — src/app/validate/page.tsx, Server shell)
+│   └── ChatInterface (Client)              — orchestrates session; idea input form + chat UI
+│       ├── MessageList (Client)            — renders conversation history
+│       │   ├── UserMessage (Client)
+│       │   └── AssistantMessage (Client)
+│       │       └── StreamingText (Client) — token-level stream render
+│       ├── ChatInput (Client)              — text input + send / stop button
+│       ├── PhaseIndicator (Client)         — Brain Dump / Discovery / Research / Findings / Complete
+│       ├── SearchingIndicator (Client)     — search-query log + dots during research phase
+│       ├── ScorePanel (Client)             — live Desirability/Viability/Feasibility + kill signals
+│       ├── DownloadButton (Client)         — generates + downloads discovery.md (with inline error)
+│       └── FullBundlePointer (Client)      — shown on complete; Stripe checkout for paid bundle
+│
+└── /deck/[orderId] (Route Handler)         — serves fulfilled deck HTML from Supabase Storage
 
 Hooks (src/hooks/)
 ├── useStream                              — wraps fetch + ReadableStream for /api/* calls
@@ -58,14 +60,21 @@ Server-side libraries (src/lib/, all "server-only" where applicable)
 ├── anthropic.ts                           — Anthropic SDK client (server-only guard)
 ├── prompts.ts                             — Fast Check + Full Validation system prompts
 ├── rate-limit.ts                          — Upstash + in-memory limiter, getClientIp helper
+├── spend-ledger.ts                        — daily Anthropic-spend circuit breaker (Upstash)
 ├── streaming.ts                           — line-based stream parser shared by hooks
 ├── markdown.ts                            — discovery.md generation for download
 ├── session.ts                             — localStorage schema + CRUD
+├── orders.ts / fulfilment.ts              — Supabase order lifecycle + automated fulfilment
+├── deck/                                  — deck template + Supabase Storage read/write
 └── utils.ts                               — cn() + getRelativeTime()
 
 API Route Handlers (server-side only)
 ├── POST /api/fast                         — single-shot Fast Check (rate-limited 10/min)
-└── POST /api/chat                         — streaming Full Validation turns (rate-limited 5/min)
+├── POST /api/chat                         — streaming Full Validation turns (rate-limited 5/min)
+├── POST /api/waitlist                     — email capture when spend cap hit (Supabase INSERT)
+├── POST /api/woz-intent                   — Wizard-of-Oz purchase intent capture (Supabase)
+├── POST /api/stripe/checkout              — creates Stripe Checkout session for paid bundle
+└── POST /api/stripe/webhook               — Stripe webhook (signature-verified, idempotent)
 
 Middleware
 └── src/middleware.ts                      — origin guard for /api/* (CORS, derives allowed origin from Host)
@@ -836,11 +845,18 @@ Fonts are loaded via `next/font/google` (self-hosted at build time) rather than 
 ### Environment Variables
 
 Required in production (Vercel environment settings):
+
 ```
 ANTHROPIC_API_KEY=sk-ant-...
+UPSTASH_REDIS_REST_URL=...          # rate limiting + spend ledger
+UPSTASH_REDIS_REST_TOKEN=...
+SUPABASE_URL=...                    # waitlist, orders, woz-intent, deck storage
+SUPABASE_SERVICE_ROLE_KEY=...       # server-side writes (webhook, fulfilment)
+STRIPE_SECRET_KEY=...               # checkout + webhook verification
+STRIPE_WEBHOOK_SECRET=...
 ```
 
-No other secrets. No database credentials. No third-party API keys.
+See `web/.env.example` for the full list including optional vars (PostHog, Resend, spend ceilings). Session state is **not** stored server-side — only transactional records (waitlist, orders) hit Supabase.
 
 ---
 
@@ -879,11 +895,11 @@ No other secrets. No database credentials. No third-party API keys.
 **Rejected:** Server-Sent Events (`Content-Type: text/event-stream`), `@ai-sdk/react` useChat hook.
 **Rationale:** `useChat` from the Vercel AI SDK accumulates the full response before exposing it, which defeats streaming. The custom protocol is lightweight (20 lines of client parsing code) and gives precise control over event timing. SSE would require consistent event formatting; mixing prose and structured events is simpler with the custom line-based approach.
 
-### Decision 3: localStorage, no database
+### Decision 3: localStorage for sessions, Supabase for transactional data
 
-**Chosen:** localStorage for session state.
-**Rejected:** Supabase, PlanetScale, Redis.
-**Rationale:** No auth, no user accounts. A database would require user identification. localStorage is sufficient for single-browser session continuity. The privacy model is explicit: data stays in the browser, nothing is sent to a server except active API calls.
+**Chosen:** localStorage for Full Validation session state; Supabase for waitlist, orders, woz-intent, and deck storage; Stripe for paid checkout.
+**Rejected (for sessions):** Server-side session tracking, user accounts.
+**Rationale:** Chat sessions remain anonymous and browser-local — no login required. Supabase backs only server-initiated transactional records (email capture, paid orders, fulfilment artefacts) where persistence across requests is necessary. The privacy model for conversation content is explicit: idea text and chat history stay in the browser except during active API calls.
 
 ### Decision 4: POST for all routes
 
@@ -895,7 +911,7 @@ No other secrets. No database credentials. No third-party API keys.
 
 **Chosen:** Client sends `phase` and `scores` on every request.
 **Rejected:** Server-side session tracking.
-**Rationale:** Stateless server is simpler, cheaper, and matches the no-database constraint. The client is the source of truth for session state (backed by localStorage). The server only needs the current state to inject into the system prompt — it does not need history.
+**Rationale:** Stateless server for chat is simpler and cheaper. The client is the source of truth for session state (backed by localStorage). The server only needs the current state to inject into the system prompt — it does not need server-side session history. Transactional data (orders, waitlist) is persisted separately in Supabase.
 
 ### Decision 6: Markdown download, no Gamma
 

--- a/web/README.md
+++ b/web/README.md
@@ -40,9 +40,11 @@ The session persists in localStorage so you can close the tab and resume later f
 - **Tailwind CSS v4** + shadcn/ui primitives
 - **Zod** for input validation in route handlers
 - **Upstash Redis** for distributed rate limiting (with an in-memory fallback for local dev only)
-- **Vitest** + React Testing Library — 230 tests across unit + integration
+- **Vitest** + React Testing Library — 303 tests across unit + integration
 - **Vercel** for hosting; Node.js runtime on the route handlers (Edge would break the Anthropic SDK)
-- **No database, no auth** — server is stateless, session state lives in the browser
+- **Supabase** for waitlist, orders, woz-intent, and deck storage (server-side only)
+- **Stripe** for one-off paid validation bundle checkout
+- **No user auth** — Full Validation session state lives in the browser; server is stateless for chat
 
 ---
 
@@ -154,9 +156,15 @@ web/
 │   │   ├── layout.tsx            # Loads Playfair Display + Fira Code
 │   │   ├── fast/                 # /fast — Fast Check
 │   │   ├── validate/             # /validate — Full Validation
+│   │   ├── deck/[orderId]/       # GET — served fulfilled deck HTML
 │   │   └── api/
 │   │       ├── fast/             # POST /api/fast — single-shot
-│   │       └── chat/             # POST /api/chat — streaming conversation
+│   │       ├── chat/             # POST /api/chat — streaming conversation
+│   │       ├── waitlist/         # POST /api/waitlist — spend-cap email capture
+│   │       ├── woz-intent/       # POST /api/woz-intent — purchase intent
+│   │       └── stripe/
+│   │           ├── checkout/     # POST /api/stripe/checkout
+│   │           └── webhook/      # POST /api/stripe/webhook
 │   ├── components/
 │   │   ├── home/ResumeSessionBanner.tsx     # Reads localStorage, offers resume
 │   │   ├── fast/                            # FastPageContent + FastInput + FastStream
@@ -172,13 +180,16 @@ web/
 │   │   ├── anthropic.ts          # Anthropic client (server-only guard)
 │   │   ├── prompts.ts            # System prompts for both modes
 │   │   ├── rate-limit.ts         # Upstash + in-memory limiter, getClientIp
+│   │   ├── spend-ledger.ts       # Daily Anthropic-spend circuit breaker
 │   │   ├── streaming.ts          # Line-based stream parser
 │   │   ├── markdown.ts           # discovery.md generator for download
 │   │   ├── session.ts            # localStorage CRUD
+│   │   ├── orders.ts             # Supabase order lifecycle
+│   │   ├── fulfilment.ts         # Automated post-payment fulfilment
 │   │   └── utils.ts              # cn() + getRelativeTime
 │   ├── middleware.ts             # Origin guard for /api/*
 │   └── types/index.ts            # All shared TypeScript interfaces
-└── tests/                        # Unit + integration (230 tests)
+└── tests/                        # Unit + integration (303 tests)
 ```
 
 For the long-form architecture, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 0 of the [codebase hardening plan](docs/plans/2026-08-02-codebase-hardening-plan.md): quick wins with no product behaviour change.

### Changes

1. **Docs-sync scope** — `scripts/check-docs-sync.sh` and `.claude/settings.json` PreToolUse hook now enforce doc updates when `studio/src/` or `packages/` change (matching `AGENTS.md`). Added `studio/README.md` to the doc paths list.

2. **Architecture refresh** — `web/ARCHITECTURE.md` §1 and component diagram updated for Supabase (waitlist, orders, deck storage), Stripe checkout/webhook, and the full API route inventory. Decision 3 revised: localStorage for sessions, Supabase for transactional data.

3. **README accuracy** — `web/README.md` test count (303), tech stack, and project structure tree updated.

4. **Settings security** — Removed Bash allow-all from `web/.claude/settings.json`; tsc advisory hook now uses `git rev-parse --show-toplevel` instead of a hardcoded Mac path.

### Verify

```bash
scripts/check-docs-sync.sh   # passes on this PR (docs + code changed together)
```

### Next

Phase 1 (PR 2): CI matrix for web + studio + core, Studio ESLint, core Vitest scaffold.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8907759a-6106-4520-bec3-bb88d0f90954?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8907759a-6106-4520-bec3-bb88d0f90954&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

