### PR TITLE
test: Phase 2 codebase hardening — core fixtures + Stripe webhook tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 .env.*.local
 # ProveIt generated research files (session artifacts — not for source control)
 discovery.md
+!packages/core/tests/fixtures/**
 research-*.md
 swarm-*.md
 review-*.md

--- a/packages/core/tests/fast-check.test.ts
+++ b/packages/core/tests/fast-check.test.ts
@@ -1,0 +1,41 @@
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parseFastCheckNote, scanFastChecks } from "../src/fast-check.ts";
+
+const FIXTURES = join(import.meta.dirname, "fixtures", "fast-check");
+
+describe("parseFastCheckNote", () => {
+  it("parses multi-idea fast-check notes", async () => {
+    const text = await readFile(join(FIXTURES, "portfolio-fast.md"), "utf8");
+    const ideas = parseFastCheckNote(text, "portfolio-fast.md");
+
+    expect(ideas).toHaveLength(2);
+    expect(ideas[0].name).toBe("Rooftop Beekeeping SaaS");
+    expect(ideas[0].verdict).toMatch(/weak/i);
+    expect(ideas[0].assessments.length).toBeGreaterThanOrEqual(2);
+    expect(ideas[0].insight).toMatch(/B2B apiary/i);
+    expect(ideas[0].date).toBe("2026-07-15");
+    expect(ideas[1].slug).toBe("ai-resume-rewriter");
+  });
+
+  it("skips sections without enough dimension verdicts", () => {
+    const text = `# /proveit-fast on 2026-01-01
+
+## Incomplete Section
+
+**Verdict: Weak**
+
+- Only one line here
+`;
+    expect(parseFastCheckNote(text, "incomplete.md")).toHaveLength(0);
+  });
+});
+
+describe("scanFastChecks", () => {
+  it("finds fast-check notes by content markers", async () => {
+    const ideas = await scanFastChecks([FIXTURES]);
+    expect(ideas.length).toBeGreaterThanOrEqual(2);
+    expect(ideas.every((i) => i.source.includes("portfolio-fast.md"))).toBe(true);
+  });
+});

--- a/packages/core/tests/fixtures/dedup/00_Index.md
+++ b/packages/core/tests/fixtures/dedup/00_Index.md
@@ -1,0 +1,6 @@
+# ProveIt: Index Recap
+
+## Confidence Score
+Desirability: 5/10 | Viability: 5/10 | Feasibility: 5/10
+
+This index recaps scores from the real discovery file in this folder.

--- a/packages/core/tests/fixtures/dedup/discovery.md
+++ b/packages/core/tests/fixtures/dedup/discovery.md
@@ -1,0 +1,7 @@
+# ProveIt: Dedup Winner
+
+## Confidence Score
+Desirability: 9/10 | Viability: 8/10 | Feasibility: 7/10
+
+## Recommendation
+The canonical discovery index for this folder.

--- a/packages/core/tests/fixtures/edge/no-scores.md
+++ b/packages/core/tests/fixtures/edge/no-scores.md
@@ -1,0 +1,7 @@
+# ProveIt: Not A Real Discovery
+
+## Confidence Score
+No numeric scores here — just narrative.
+
+## Recommendation
+Should not be picked up by scanRoots.

--- a/packages/core/tests/fixtures/edge/random-note.md
+++ b/packages/core/tests/fixtures/edge/random-note.md
@@ -1,0 +1,3 @@
+# Random Meeting Notes
+
+Just a note with no ProveIt markers.

--- a/packages/core/tests/fixtures/fast-check/portfolio-fast.md
+++ b/packages/core/tests/fixtures/fast-check/portfolio-fast.md
@@ -1,0 +1,18 @@
+# Fast checks — /proveit-fast on 2026-07-15
+
+## Rooftop Beekeeping SaaS
+
+**Verdict: Weak overall**
+
+- Desirability: WEAK — niche hobbyist market
+- Viability: SUPPORTED — subscription models exist in adjacent spaces
+- Competition: CONTRADICTED — incumbents already serve pro apiaries
+- Key insight: B2B apiary ops is the only credible wedge
+
+## AI Resume Rewriter
+
+**Verdict: Contradicted**
+
+- Desirability: SUPPORTED — job seekers want help
+- Distribution: WEAK — CAC likely exceeds LTV at consumer price points
+- Key insight: Commoditized before launch

--- a/packages/core/tests/fixtures/numbered/01_Discovery.md
+++ b/packages/core/tests/fixtures/numbered/01_Discovery.md
@@ -1,0 +1,7 @@
+# ProveIt: Numbered Convention Idea
+
+## Confidence Score
+Desirability: 7/10 | Viability: 7/10 | Feasibility: 6/10
+
+## Recommendation
+Worth a deeper validation pass.

--- a/packages/core/tests/fixtures/standard/discovery.md
+++ b/packages/core/tests/fixtures/standard/discovery.md
@@ -1,0 +1,15 @@
+# ProveIt: Holiday Portfolio Planner
+
+## Confidence Score
+Desirability: 8/10 | Viability: 6/10 | Feasibility: 5/10
+Status: Go with caution
+
+## Idea (Brain Dump)
+One-liner: Help families plan school-holiday activities without the spreadsheet chaos.
+
+## Kill Signals
+- **Market saturation** — crowded planner space
+- **Resolved: pricing** — validated willingness to pay
+
+## Recommendation
+Proceed to a focused MVP for working parents.

--- a/packages/core/tests/scan.test.ts
+++ b/packages/core/tests/scan.test.ts
@@ -1,0 +1,191 @@
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  activeKillCount,
+  classifyArtifact,
+  combined,
+  discoveryLikelihood,
+  loadIdea,
+  parseDiscovery,
+  scanRoots,
+  slugify,
+} from "../src/scan.ts";
+
+const FIXTURES = join(import.meta.dirname, "fixtures");
+
+async function readFixture(...parts: string[]): Promise<string> {
+  return readFile(join(FIXTURES, ...parts), "utf8");
+}
+
+describe("slugify", () => {
+  it("normalises em dashes and punctuation", () => {
+    expect(slugify("ProveIt: My — Great Idea")).toBe("proveit-my-great-idea");
+  });
+
+  it("truncates to 60 characters", () => {
+    expect(slugify("a".repeat(80))).toHaveLength(60);
+  });
+});
+
+describe("discoveryLikelihood", () => {
+  it("scores canonical discovery higher than index recap", async () => {
+    const discovery = await readFixture("dedup", "discovery.md");
+    const index = await readFixture("dedup", "00_Index.md");
+    expect(discoveryLikelihood(discovery, "discovery.md")).toBeGreaterThan(
+      discoveryLikelihood(index, "00_Index.md"),
+    );
+  });
+
+  it("prefers discovery.md filename over index", async () => {
+    const text = await readFixture("standard", "discovery.md");
+    expect(discoveryLikelihood(text, "discovery.md")).toBeGreaterThan(
+      discoveryLikelihood(text, "00_Index.md"),
+    );
+  });
+});
+
+describe("parseDiscovery", () => {
+  it("parses standard discovery scores and metadata", async () => {
+    const text = await readFixture("standard", "discovery.md");
+    const parsed = parseDiscovery(text);
+
+    expect(parsed.name).toBe("Holiday Portfolio Planner");
+    expect(parsed.scores.desirability).toBe(8);
+    expect(parsed.scores.viability).toBe(6);
+    expect(parsed.scores.feasibility).toBe(5);
+    expect(parsed.status).toBe("Go with caution");
+    expect(parsed.oneLiner).toMatch(/school-holiday/i);
+    expect(parsed.recommendation).toMatch(/MVP/i);
+  });
+
+  it("parses kill signal statuses", async () => {
+    const text = await readFixture("standard", "discovery.md");
+    const parsed = parseDiscovery(text);
+
+    expect(parsed.killSignals).toHaveLength(2);
+    expect(parsed.killSignals.find((k) => k.label.includes("saturation"))?.status).toBe(
+      "active",
+    );
+    expect(parsed.killSignals.find((k) => k.label.includes("pricing"))?.status).toBe(
+      "resolved",
+    );
+    expect(activeKillCount(parsed.killSignals)).toBe(1);
+  });
+
+  it("parses numbered convention files", async () => {
+    const text = await readFixture("numbered", "01_Discovery.md");
+    const parsed = parseDiscovery(text);
+
+    expect(parsed.name).toBe("Numbered Convention Idea");
+    expect(combined(parsed.scores)).toBe(20);
+  });
+});
+
+describe("classifyArtifact", () => {
+  it("classifies standard swarm and research names", () => {
+    expect(classifyArtifact("swarm-1-market-bull.md")).toMatchObject({
+      kind: "swarm-angle",
+      round: 1,
+    });
+    expect(classifyArtifact("research-2.md")).toMatchObject({
+      kind: "research",
+      round: 2,
+    });
+    expect(classifyArtifact("discovery.md")).toMatchObject({ kind: "discovery" });
+    expect(classifyArtifact("spec.md")).toMatchObject({ kind: "spec" });
+  });
+
+  it("classifies numbered convention names", () => {
+    expect(classifyArtifact("21_Swarm_1_Market_Bull.md")).toMatchObject({
+      kind: "swarm-angle",
+      round: 1,
+    });
+    expect(classifyArtifact("01_Discovery.md")).toMatchObject({ kind: "discovery" });
+    expect(classifyArtifact("00_Index.md")).toMatchObject({ kind: "index" });
+  });
+
+  it("returns null for unrelated markdown in a shared folder", () => {
+    expect(classifyArtifact("meeting-notes.md")).toBeNull();
+    expect(classifyArtifact("README.md")).toBeNull();
+  });
+
+  it("includes numbered notes in dedicated ProveIt folders", () => {
+    expect(
+      classifyArtifact("03_Product_Evolution.md", { dedicatedDir: true }),
+    ).toMatchObject({ kind: "other" });
+  });
+});
+
+describe("scanRoots", () => {
+  it("finds standard and numbered discoveries", async () => {
+    const summaries = await scanRoots([
+      join(FIXTURES, "standard"),
+      join(FIXTURES, "numbered"),
+    ]);
+
+    expect(summaries.map((s) => s.slug).sort()).toEqual(
+      ["holiday-portfolio-planner", "numbered-convention-idea"].sort(),
+    );
+    expect(summaries.every((s) => s.source === "fs")).toBe(true);
+  });
+
+  it("dedupes index recap vs real discovery in the same folder", async () => {
+    const summaries = await scanRoots([join(FIXTURES, "dedup")]);
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].name).toBe("Dedup Winner");
+    expect(summaries[0].scores.desirability).toBe(9);
+  });
+
+  it("ignores files without score lines", async () => {
+    const summaries = await scanRoots([join(FIXTURES, "edge")]);
+    expect(summaries).toHaveLength(0);
+  });
+
+  it("respects MAX_DEPTH and ignores dot directories", async () => {
+    const root = await mkdtemp(join(tmpdir(), "proveit-scan-"));
+    const deep = join(root, "a", "b", "c", "d", "e", "f", "g", "h");
+    await mkdir(deep, { recursive: true });
+    await writeFile(
+      join(deep, "discovery.md"),
+      `# ProveIt: Too Deep
+
+## Confidence Score
+Desirability: 1/10 | Viability: 1/10 | Feasibility: 1/10
+`,
+    );
+    await mkdir(join(root, ".hidden"), { recursive: true });
+    await writeFile(
+      join(root, ".hidden", "discovery.md"),
+      `# ProveIt: Hidden
+
+## Confidence Score
+Desirability: 10/10 | Viability: 10/10 | Feasibility: 10/10
+`,
+    );
+
+    const summaries = await scanRoots([root]);
+    expect(summaries).toHaveLength(0);
+  });
+});
+
+describe("loadIdea", () => {
+  it("loads discovery detail and sibling artifacts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "proveit-load-"));
+    await writeFile(join(root, "discovery.md"), await readFixture("standard", "discovery.md"));
+    await writeFile(join(root, "swarm-1-market-bull.md"), "# Swarm angle\n");
+    await writeFile(join(root, "research-1.md"), "# Research\n");
+    await writeFile(join(root, "random.md"), "# Ignored\n");
+
+    const idea = await loadIdea(join(root, "discovery.md"));
+
+    expect(idea.slug).toBe("holiday-portfolio-planner");
+    expect(idea.artifacts.map((a) => a.kind).sort()).toEqual(
+      ["research", "swarm-angle"].sort(),
+    );
+    expect(idea.artifactCount).toBe(2);
+    expect(idea.brainDump).toMatch(/spreadsheet chaos/i);
+  });
+});

--- a/studio/README.md
+++ b/studio/README.md
@@ -33,7 +33,7 @@ The reader reads the vault **live** off disk — no build step, no sync, nothing
 npm run lint -w proveit-studio     # ESLint (next/core-web-vitals)
 npx tsc --noEmit                   # from studio/
 npm run build -w proveit-studio
-npm test -w @proveit/core          # shared scan/parse tests (packages/core)
+npm test -w @proveit/core          # shared scan/parse tests (21 tests, fixture-backed)
 ```
 
 CI runs lint, typecheck, and build for Studio plus tests for `@proveit/core` on PRs to `main` and `feat/proveit-studio` (see `.github/workflows/ci.yml`).

--- a/web/README.md
+++ b/web/README.md
@@ -40,7 +40,7 @@ The session persists in localStorage so you can close the tab and resume later f
 - **Tailwind CSS v4** + shadcn/ui primitives
 - **Zod** for input validation in route handlers
 - **Upstash Redis** for distributed rate limiting (with an in-memory fallback for local dev only)
-- **Vitest** + React Testing Library — 303 tests across unit + integration
+- **Vitest** + React Testing Library — 311 tests across unit + integration
 - **Vercel** for hosting; Node.js runtime on the route handlers (Edge would break the Anthropic SDK)
 - **Supabase** for waitlist, orders, woz-intent, and deck storage (server-side only)
 - **Stripe** for one-off paid validation bundle checkout
@@ -189,7 +189,7 @@ web/
 │   │   └── utils.ts              # cn() + getRelativeTime
 │   ├── middleware.ts             # Origin guard for /api/*
 │   └── types/index.ts            # All shared TypeScript interfaces
-└── tests/                        # Unit + integration (303 tests)
+└── tests/                        # Unit + integration (311 tests)
 ```
 
 For the long-form architecture, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).

--- a/web/tests/integration/api-stripe-webhook.test.ts
+++ b/web/tests/integration/api-stripe-webhook.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration tests for POST /api/stripe/webhook
+ *
+ * Verifies signature gate, idempotency, side-effect wiring, and fail-closed
+ * error handling on the paid path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const mockConstructEvent = vi.fn();
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: vi.fn(),
+  resetStripeClient: vi.fn(),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  notifyOrderPaid: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/fulfilment", () => ({
+  fulfilOrder: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/analytics-server", () => ({
+  captureServer: vi.fn().mockResolvedValue(undefined),
+  resetAnalyticsClient: vi.fn(),
+}));
+
+import { POST } from "@/app/api/stripe/webhook/route";
+import { getStripe } from "@/lib/stripe";
+import {
+  createPendingOrder,
+  markOrderPaid,
+  resetOrderStores,
+} from "@/lib/orders";
+import * as ordersMod from "@/lib/orders";
+import { notifyOrderPaid } from "@/lib/notifications";
+import { fulfilOrder } from "@/lib/fulfilment";
+import { captureServer } from "@/lib/analytics-server";
+
+const SESSION_ID = "cs_test_webhook_123";
+
+function checkoutCompletedEvent(sessionId = SESSION_ID) {
+  return {
+    type: "checkout.session.completed",
+    data: {
+      object: {
+        id: sessionId,
+        customer_details: { email: "buyer@example.com" },
+        amount_total: 499,
+        currency: "gbp",
+        metadata: {
+          proveit_session_id: "proveit_sess_1",
+          idea_summary: "A validated idea",
+        },
+      },
+    },
+  };
+}
+
+function makeWebhookRequest(
+  body = JSON.stringify({ id: "evt_test" }),
+  headers: Record<string, string> = { "stripe-signature": "sig_test" },
+): NextRequest {
+  return new NextRequest("http://localhost/api/stripe/webhook", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body,
+  });
+}
+
+describe("POST /api/stripe/webhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetOrderStores();
+    process.env.STRIPE_SECRET_KEY = "sk_test_webhook";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+    vi.mocked(getStripe).mockReturnValue({
+      webhooks: { constructEvent: mockConstructEvent },
+    } as unknown as ReturnType<typeof getStripe>);
+  });
+
+  it("returns 503 when Stripe is not configured", async () => {
+    vi.mocked(getStripe).mockReturnValue(null);
+
+    const res = await POST(makeWebhookRequest());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: "Stripe not configured" });
+  });
+
+  it("returns 503 when webhook secret is unset", async () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+
+    const res = await POST(makeWebhookRequest());
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: "Webhook secret not configured" });
+  });
+
+  it("returns 400 when Stripe-Signature header is missing", async () => {
+    const res = await POST(makeWebhookRequest("{}", {}));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "Missing Stripe-Signature header" });
+    expect(mockConstructEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when signature verification fails", async () => {
+    mockConstructEvent.mockImplementation(() => {
+      throw new Error("Invalid signature");
+    });
+
+    const res = await POST(makeWebhookRequest());
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: "Signature verification failed" });
+  });
+
+  it("returns 200 for non-checkout event types without side effects", async () => {
+    mockConstructEvent.mockReturnValue({ type: "customer.created", data: { object: {} } });
+
+    const res = await POST(makeWebhookRequest());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ received: true });
+    expect(notifyOrderPaid).not.toHaveBeenCalled();
+    expect(fulfilOrder).not.toHaveBeenCalled();
+  });
+
+  it("marks order paid and triggers notify + fulfilment on first delivery", async () => {
+    await createPendingOrder({
+      checkoutSessionId: SESSION_ID,
+      proveitSessionId: "proveit_sess_1",
+      ideaSummary: "A validated idea",
+    });
+    mockConstructEvent.mockReturnValue(checkoutCompletedEvent());
+
+    const res = await POST(makeWebhookRequest());
+    expect(res.status).toBe(200);
+
+    expect(notifyOrderPaid).toHaveBeenCalledOnce();
+    expect(notifyOrderPaid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "buyer@example.com",
+        ideaSummary: "A validated idea",
+      }),
+    );
+    expect(captureServer).toHaveBeenCalledWith(
+      "checkout_completed",
+      "proveit_sess_1",
+      expect.objectContaining({ checkout_session_id: SESSION_ID }),
+    );
+    expect(fulfilOrder).toHaveBeenCalledOnce();
+  });
+
+  it("is idempotent — duplicate webhook does not re-notify", async () => {
+    await createPendingOrder({ checkoutSessionId: SESSION_ID });
+    await markOrderPaid(SESSION_ID, "buyer@example.com");
+    mockConstructEvent.mockReturnValue(checkoutCompletedEvent());
+
+    const res = await POST(makeWebhookRequest());
+    expect(res.status).toBe(200);
+    expect(notifyOrderPaid).not.toHaveBeenCalled();
+    expect(fulfilOrder).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when markOrderPaid throws so Stripe retries", async () => {
+    mockConstructEvent.mockReturnValue(checkoutCompletedEvent("cs_throws"));
+    vi.spyOn(ordersMod, "markOrderPaid").mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+
+    const res = await POST(makeWebhookRequest());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: "Internal processing error" });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 of the [codebase hardening plan](docs/plans/2026-08-02-codebase-hardening-plan.md).

### Changes

1. **`@proveit/core` fixture tests (21 tests total)**
   - `scan.test.ts` — slugify, discoveryLikelihood, parseDiscovery, classifyArtifact (standard + numbered naming), scanRoots dedup, MAX_DEPTH, loadIdea artifacts
   - `fast-check.test.ts` — parseFastCheckNote, scanFastChecks
   - Realistic vault fixtures under `packages/core/tests/fixtures/`

2. **Stripe webhook integration tests (8 tests)**
   - 503 when Stripe/secret unconfigured
   - 400 on missing/invalid signature
   - 200 for ignored event types
   - First delivery → notify + fulfilment + analytics
   - Idempotent duplicate delivery
   - 500 when processing throws (Stripe retry path)

3. **Gitignore fix** — `discovery.md` global ignore was excluding test fixtures; added `!packages/core/tests/fixtures/**`

4. **Docs** — web README test count (311), studio README core test note

### Verify

```bash
npm test -w @proveit/core          # 21 passed
cd web && npm test -- --run        # 311 passed
```

### Next

Phase 3: hook/component tests + local Playwright E2E.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8907759a-6106-4520-bec3-bb88d0f90954?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8907759a-6106-4520-bec3-bb88d0f90954&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

