### PR TITLE
test: Phase 3 codebase hardening — UI tests + Playwright E2E

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -6,6 +6,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
 
 # next.js
 /.next/

--- a/web/README.md
+++ b/web/README.md
@@ -191,7 +191,7 @@ web/
 │   │   └── utils.ts              # cn() + getRelativeTime
 │   ├── middleware.ts             # Origin guard for /api/*
 │   └── types/index.ts            # All shared TypeScript interfaces
-└── tests/                        # Unit + integration (311 tests)
+└── tests/                        # Unit + integration (328 tests) + e2e/
 ```
 
 For the long-form architecture, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).

--- a/web/README.md
+++ b/web/README.md
@@ -40,7 +40,7 @@ The session persists in localStorage so you can close the tab and resume later f
 - **Tailwind CSS v4** + shadcn/ui primitives
 - **Zod** for input validation in route handlers
 - **Upstash Redis** for distributed rate limiting (with an in-memory fallback for local dev only)
-- **Vitest** + React Testing Library — 311 tests across unit + integration
+- **Vitest** + React Testing Library — 328 tests across unit + integration
 - **Vercel** for hosting; Node.js runtime on the route handlers (Edge would break the Anthropic SDK)
 - **Supabase** for waitlist, orders, woz-intent, and deck storage (server-side only)
 - **Stripe** for one-off paid validation bundle checkout
@@ -124,6 +124,8 @@ npm run build      # Production build
 npm run lint       # ESLint
 npm run test       # Vitest in watch mode
 npm run test:run   # Vitest one-shot
+npm run e2e:install # One-time Playwright browser install
+npm run e2e        # Local Playwright E2E (mocked API routes)
 ```
 
 Tests live in `tests/unit/` (component + utility tests) and `tests/integration/` (API route handler tests). The route handler tests mock the Anthropic SDK at module level via Vitest.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,6 +32,7 @@
         "zod": "3.25.23"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@posthog/cli": "^0.7.11",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "16.3.0",
@@ -2247,6 +2248,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@posthog/cli": {
@@ -9775,6 +9792,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,9 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install chromium"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.95.1",
@@ -36,6 +38,7 @@
     "zod": "3.25.23"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@posthog/cli": "^0.7.11",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "16.3.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev -- --port 3000",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+    env: {
+      ANTHROPIC_API_KEY: "sk-ant-e2e-placeholder-not-real",
+    },
+  },
+});

--- a/web/tests/e2e/fast-check.spec.ts
+++ b/web/tests/e2e/fast-check.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@playwright/test";
+
+const fastStreamBody = `**Assumption 1: Desirability — Teams need async standups**
+
+Verdict: SUPPORTED
+
+Evidence:
+- remote-work.com: Distributed teams report daily coordination friction
+
+**Assumption 2: Viability — Budget exists for team tools**
+
+Verdict: WEAK
+
+Evidence:
+- pricing-surveys.com: SMB spend remains constrained
+
+**Quick verdict:** Desirability looks real, but monetisation is the risk.
+`;
+
+test("fast check renders assumption cards from mocked stream", async ({ page }) => {
+  await page.route("**/api/fast", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+      body: fastStreamBody,
+    });
+  });
+
+  await page.goto("/fast");
+  await page
+    .getByRole("textbox", { name: /describe your product idea/i })
+    .fill("Async standup tool for distributed engineering teams");
+  await page.getByRole("button", { name: /run fast check/i }).click();
+
+  await expect(page.getByText("FAST CHECK")).toBeVisible();
+  await expect(page.getByText("SUPPORTED")).toBeVisible();
+  await expect(page.getByText(/monetisation is the risk/i)).toBeVisible();
+});

--- a/web/tests/e2e/validate-flow.spec.ts
+++ b/web/tests/e2e/validate-flow.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+test("validate flow opens chat after idea submit", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  await page.route("**/api/chat", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+      body: "Welcome — tell me more about the problem you are solving.\n",
+    });
+  });
+
+  await page.goto("/validate");
+  await page
+    .getByRole("textbox", { name: /describe your product idea/i })
+    .fill("A calendar app that schedules focus blocks for engineers automatically");
+  await page.getByRole("button", { name: /start validation/i }).click();
+
+  await expect(page.getByLabel(/Phase 1 of 4: BRAIN DUMP/i)).toBeVisible();
+  await expect(page.getByText(/Welcome — tell me more/i)).toBeVisible();
+  await expect(page.getByRole("textbox", { name: /type your answer/i })).toBeVisible();
+});

--- a/web/tests/unit/chat-interface.test.tsx
+++ b/web/tests/unit/chat-interface.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ValidationSession } from "@/types";
+
+const { mockUseSession } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  captureEvent: vi.fn(),
+}));
+
+vi.mock("@/hooks/useStream", () => ({
+  useStream: () => ({
+    isStreaming: false,
+    error: null,
+    errorReason: null,
+    startStream: vi.fn().mockResolvedValue(undefined),
+    stopStream: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useSession", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+import ChatInterface from "@/components/validate/ChatInterface";
+
+const incompleteSession: ValidationSession = {
+  id: "sess_resume",
+  ideaSummary: "Async standup tool for distributed engineering teams",
+  phase: "discovery",
+  messages: [],
+  scores: { desirability: null, viability: null, feasibility: null },
+  killSignals: [],
+  researchComplete: false,
+  createdAt: Date.now() - 3_600_000,
+  updatedAt: Date.now() - 3_600_000,
+};
+
+describe("ChatInterface", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+    mockUseSession.mockReturnValue({
+      session: null,
+      updateSession: vi.fn(),
+      clearSession: vi.fn(),
+    });
+  });
+
+  it("shows resume prompt for an incomplete stored session", () => {
+    mockUseSession.mockReturnValue({
+      session: incompleteSession,
+      updateSession: vi.fn(),
+      clearSession: vi.fn(),
+    });
+
+    render(<ChatInterface />);
+
+    expect(screen.getByText("PREVIOUS SESSION")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /resume session/i })).toBeInTheDocument();
+    expect(screen.getByText(/Discovery in progress/i)).toBeInTheDocument();
+  });
+
+  it("validates minimum idea length before starting", async () => {
+    const user = userEvent.setup();
+    render(<ChatInterface />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /describe your product idea/i }),
+      "Too short",
+    );
+    await user.click(screen.getByRole("button", { name: /start validation/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Tell us a bit more about the idea",
+    );
+  });
+
+  it("shows phase indicator after starting a new session", async () => {
+    const user = userEvent.setup();
+    render(<ChatInterface />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /describe your product idea/i }),
+      "A calendar app that schedules focus blocks for engineers automatically",
+    );
+    await user.click(screen.getByRole("button", { name: /start validation/i }));
+
+    expect(await screen.findByLabelText(/Phase 1 of 4: BRAIN DUMP/i)).toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/download-button.test.tsx
+++ b/web/tests/unit/download-button.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DownloadButton from "@/components/validate/DownloadButton";
+import type { ValidationSession } from "@/types";
+
+const session: ValidationSession = {
+  id: "sess_download",
+  ideaSummary: "Async standup tool for distributed teams",
+  phase: "complete",
+  messages: [
+    {
+      id: "m1",
+      role: "assistant",
+      content: "Summary content for the download.",
+      timestamp: Date.now(),
+    },
+  ],
+  scores: { desirability: 7, viability: 6, feasibility: 5 },
+  killSignals: [],
+  researchComplete: true,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+describe("DownloadButton", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(global.URL, "createObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => "blob:proveit-test"),
+    });
+    Object.defineProperty(global.URL, "revokeObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("generates and triggers a markdown download", async () => {
+    const user = userEvent.setup();
+    const click = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+
+    vi.spyOn(document, "createElement").mockImplementation((tagName, options) => {
+      const el = originalCreateElement(tagName, options);
+      if (tagName === "a") {
+        el.click = click;
+      }
+      return el;
+    });
+
+    render(<DownloadButton session={session} />);
+    await user.click(screen.getByRole("button", { name: /download summary/i }));
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(click).toHaveBeenCalled();
+  });
+});

--- a/web/tests/unit/email-capture-form.test.tsx
+++ b/web/tests/unit/email-capture-form.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EmailCaptureForm from "@/components/EmailCaptureForm";
+
+vi.mock("@/lib/posthog", () => ({
+  captureEvent: vi.fn(),
+}));
+
+describe("EmailCaptureForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      }),
+    );
+  });
+
+  it("renders waitlist copy for global_cap", () => {
+    render(<EmailCaptureForm reason="global_cap" ideaExcerpt="My product idea" />);
+    expect(screen.getByText(/Want more access/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /let me know/i })).toBeDisabled();
+  });
+
+  it("submits email to /api/waitlist and shows thanks state", async () => {
+    const user = userEvent.setup();
+    const onSubmitted = vi.fn();
+
+    render(
+      <EmailCaptureForm
+        reason="per_ip_cap"
+        ideaExcerpt="Focus scheduling for engineers"
+        onSubmitted={onSubmitted}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/email address/i), "pm@example.com");
+    await user.type(
+      screen.getByLabelText(/optional note/i),
+      "Hit the daily cap while testing",
+    );
+    await user.click(screen.getByRole("button", { name: /let me know/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/Thanks/i);
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/waitlist",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("pm@example.com"),
+      }),
+    );
+    expect(onSubmitted).toHaveBeenCalledOnce();
+  });
+
+  it("shows server error message on failed submit", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: "That email looks invalid" }),
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<EmailCaptureForm reason="global_cap" />);
+
+    await user.type(screen.getByLabelText(/email address/i), "bad@example.com");
+    await user.click(screen.getByRole("button", { name: /let me know/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "That email looks invalid",
+    );
+  });
+});

--- a/web/tests/unit/fast-stream.test.tsx
+++ b/web/tests/unit/fast-stream.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import FastStream from "@/components/fast/FastStream";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  captureEvent: vi.fn(),
+}));
+
+const streamedAssumptions = `**Assumption 1: Desirability — Teams need async standups**
+
+Verdict: SUPPORTED
+
+Evidence:
+- remote-work.com: Distributed teams report daily coordination friction
+
+**Assumption 2: Viability — Budget exists for team tools**
+
+Verdict: WEAK
+
+Evidence:
+- pricing-surveys.com: SMB spend remains constrained
+
+**Quick verdict:** Desirability looks real, but monetisation is the risk.
+`;
+
+vi.mock("@/hooks/useStream", () => ({
+  useStream: () => ({
+    isStreaming: false,
+    error: null,
+    errorReason: null,
+    startStream: vi.fn(async (_url, _body, onText: (chunk: string) => void) => {
+      onText(streamedAssumptions);
+    }),
+  }),
+}));
+
+describe("FastStream", () => {
+  it("renders parsed assumption cards from the stream", async () => {
+    render(
+      <FastStream
+        idea="Async standup tool for distributed teams"
+        onReset={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Teams need async standups/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("SUPPORTED")).toBeInTheDocument();
+    expect(screen.getByText("WEAK")).toBeInTheDocument();
+    expect(screen.getByText(/monetisation is the risk/i)).toBeInTheDocument();
+  });
+});

--- a/web/tests/unit/use-session.test.tsx
+++ b/web/tests/unit/use-session.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useSession } from "@/hooks/useSession";
+import { createSession, getSession } from "@/lib/session";
+
+describe("useSession", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("loads an existing session from localStorage on mount", async () => {
+    createSession("An async standup tool for distributed teams");
+
+    const { result } = renderHook(() => useSession());
+
+    await waitFor(() => {
+      expect(result.current.session).not.toBeNull();
+    });
+
+    expect(result.current.session?.ideaSummary).toBe(
+      "An async standup tool for distributed teams",
+    );
+    expect(result.current.session?.phase).toBe("brain_dump");
+  });
+
+  it("updates session state and localStorage together", async () => {
+    const created = createSession("Initial idea for validation testing");
+    const { result } = renderHook(() => useSession());
+
+    await waitFor(() => expect(result.current.session?.id).toBe(created.id));
+
+    const updated = {
+      ...created,
+      phase: "discovery" as const,
+      ideaSummary: "Refined idea summary",
+    };
+
+    act(() => {
+      result.current.updateSession(updated);
+    });
+
+    expect(result.current.session?.phase).toBe("discovery");
+    expect(getSession()?.phase).toBe("discovery");
+    expect(getSession()?.ideaSummary).toBe("Refined idea summary");
+  });
+
+  it("clears session state and localStorage", async () => {
+    createSession("Temporary idea to clear");
+    const { result } = renderHook(() => useSession());
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+
+    act(() => {
+      result.current.clearSession();
+    });
+
+    expect(result.current.session).toBeNull();
+    expect(getSession()).toBeNull();
+  });
+});

--- a/web/tests/unit/use-stream.test.tsx
+++ b/web/tests/unit/use-stream.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useStream } from "@/hooks/useStream";
+import { readStream } from "@/lib/streaming";
+
+vi.mock("@/lib/streaming", () => ({
+  readStream: vi.fn(),
+}));
+
+describe("useStream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: {},
+      }),
+    );
+  });
+
+  it("streams text and clears error state on success", async () => {
+    vi.mocked(readStream).mockImplementation(async (_res, onText) => {
+      onText("Hello ");
+      onText("world");
+    });
+
+    const { result } = renderHook(() => useStream());
+    const onText = vi.fn();
+    const onEvent = vi.fn();
+
+    await act(async () => {
+      await result.current.startStream("/api/chat", { idea: "test" }, onText, onEvent);
+    });
+
+    expect(onText).toHaveBeenCalledWith("Hello ");
+    expect(onText).toHaveBeenCalledWith("world");
+    expect(result.current.error).toBeNull();
+    expect(result.current.errorReason).toBeNull();
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("sets errorReason on 503 spend-cap responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({
+          error: "ProveIt is at capacity for today.",
+          reason: "global_cap",
+        }),
+      }),
+    );
+
+    const { result } = renderHook(() => useStream());
+
+    await act(async () => {
+      await result.current.startStream("/api/fast", { idea: "test" }, vi.fn(), vi.fn());
+    });
+
+    expect(result.current.errorReason).toBe("global_cap");
+    expect(result.current.error).toMatch(/capacity/i);
+    expect(readStream).not.toHaveBeenCalled();
+  });
+
+  it("sets per_ip_cap errorReason", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({
+          error: "Daily budget reached for this connection.",
+          reason: "per_ip_cap",
+        }),
+      }),
+    );
+
+    const { result } = renderHook(() => useStream());
+
+    await act(async () => {
+      await result.current.startStream("/api/chat", {}, vi.fn(), vi.fn());
+    });
+
+    expect(result.current.errorReason).toBe("per_ip_cap");
+  });
+
+  it("uses fallback error when 503 body is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => {
+          throw new Error("not json");
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useStream());
+
+    await act(async () => {
+      await result.current.startStream("/api/fast", {}, vi.fn(), vi.fn());
+    });
+
+    expect(result.current.error).toBe("Request failed");
+    expect(result.current.errorReason).toBeNull();
+  });
+
+  it("ignores AbortError when the user stops the stream", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(Object.assign(new Error("Aborted"), { name: "AbortError" })),
+    );
+
+    const { result } = renderHook(() => useStream());
+
+    await act(async () => {
+      await result.current.startStream("/api/chat", {}, vi.fn(), vi.fn());
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it("aborts an in-flight request via stopStream", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url, init) => {
+        capturedSignal = init?.signal as AbortSignal;
+        return new Promise(() => {});
+      }),
+    );
+
+    const { result } = renderHook(() => useStream());
+
+    act(() => {
+      void result.current.startStream("/api/chat", {}, vi.fn(), vi.fn());
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(true));
+
+    act(() => {
+      result.current.stopStream();
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(result.current.isStreaming).toBe(false);
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./tests/setup.ts"],
+    exclude: ["**/node_modules/**", "**/tests/e2e/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 3 of the [codebase hardening plan](docs/plans/2026-08-02-codebase-hardening-plan.md): web UI test coverage + local Playwright E2E.

### Changes

**Hook tests**
- `useStream` — spend-cap `errorReason`, non-JSON 503, AbortError, stopStream abort
- `useSession` — load, update, clear with localStorage

**Component tests**
- `ChatInterface` — resume prompt, idea validation, phase indicator after start
- `FastStream` — stream text → AssumptionCard render
- `EmailCaptureForm` — waitlist submit + error states
- `DownloadButton` — markdown download trigger

**Playwright E2E (local)**
- `/fast` — mocked `/api/fast` stream → assumption cards
- `/validate` — mocked `/api/chat` → chat UI opens
- `npm run e2e` + `npm run e2e:install` scripts

**Other**
- Vitest excludes `tests/e2e/` (Playwright owns those)
- `web/.gitignore` — Playwright artifacts

### Verify

```bash
cd web && npm test -- --run    # 328 passed
cd web && npm run e2e          # 2 passed (after npm run e2e:install)
```

E2E is local-only for now (per plan); not added to CI yet.

### Next

Phase 4: production guardrails (Upstash required in prod, Studio email deploy guard, Dependabot).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8907759a-6106-4520-bec3-bb88d0f90954?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8907759a-6106-4520-bec3-bb88d0f90954&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

