### PR TITLE
CI: validate ProveIt agent phase files on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,17 @@ jobs:
 
       - name: Test
         run: npm test
+
+  plugin:
+    name: Plugin — agent structure
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Validate agent phase files
+        run: node scripts/validate-proveit-agent.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@ proveit/
 │   ├── mirror.ts                   # Mirror project-dir ProveIt outputs into the vault (per-idea folders)
 │   ├── sync.ts                     # Push the vault into Supabase for the hosted Studio (one-way)
 │   ├── frontier-scan.workflow.mjs  # Dynamic workflow: refreshes the frontier snapshot
-│   └── swarm.workflow.mjs          # Dynamic workflow: the Deep Dive swarm (fan-out → verify → synthesize)
+│   ├── swarm.workflow.mjs          # Dynamic workflow: the Deep Dive swarm (fan-out → verify → synthesize)
+│   └── validate-proveit-agent.mjs  # CI smoke test — orchestrator phase paths exist on disk
 ├── docs/
 │   ├── design.md               # Design decisions and validation framework
 │   ├── frontier-snapshot.md    # Living, dated record of the AI frontier (AI-currency engine)
@@ -112,6 +113,7 @@ Research phases are delegated to Sonnet subagents for speed.
 When you change `scripts/`, `agents/`, or `commands/` (the plugin), `web/src/` (the web app), **or `studio/src/` / `packages/` (ProveIt Studio)**, update the docs that describe them: `README.md`, `CLAUDE.md`, `AGENTS.md`, `docs/`, `web/README.md`, or `studio/README.md` (including the directory trees). This is **enforced**, not advisory:
 
 - **CI gate** — `.github/workflows/docs-check.yml` flags any PR where code changed without a doc update (pure bash, no LLM, no token cost).
+- **Agent structure gate** — `.github/workflows/ci.yml` (`plugin` job) runs `scripts/validate-proveit-agent.mjs` on every PR; fails if `agents/proveit.md` references a missing phase file or `proveit-fast.md` drifts from `agents/phases/fast-mode.md`.
 - **In-session reminder** — a `PreToolUse` hook in `.claude/settings.json` warns at commit time if code is staged without docs.
 - **Override** — if a change genuinely needs no doc update (e.g. a pure bugfix), put `[no-docs]` in a commit message. The check then passes.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test:core": "npm test -w @proveit/core",
     "test:web": "npm test --prefix web -- --run",
-    "lint:studio": "npm run lint -w proveit-studio"
+    "lint:studio": "npm run lint -w proveit-studio",
+    "validate:agent": "node scripts/validate-proveit-agent.mjs"
   }
 }

--- a/scripts/validate-proveit-agent.mjs
+++ b/scripts/validate-proveit-agent.mjs
@@ -1,28 +1,47 @@
 #!/usr/bin/env node
 /**
  * Smoke-test the split ProveIt agent: orchestrator phase table → files on disk.
- * Run from repo root after agent split changes.
+ * Also checks proveit-fast.md points at fast-mode.md.
+ *
+ * Run from repo root: node scripts/validate-proveit-agent.mjs
+ * CI: .github/workflows/ci.yml (plugin job)
  */
 import fs from "node:fs";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
-const orchestrator = fs.readFileSync(path.join(ROOT, "agents/proveit.md"), "utf8");
+const orchestratorPath = path.join(ROOT, "agents/proveit.md");
+const orchestrator = fs.readFileSync(orchestratorPath, "utf8");
 
-const fileRefs = [...orchestrator.matchAll(/`agents\/[^`]+`/g)].map((m) =>
-  m[0].slice(1, -1)
-);
+const fileRefs = [
+  ...new Set(
+    [...orchestrator.matchAll(/`agents\/[^`]+`/g)].map((m) => m[0].slice(1, -1))
+  ),
+];
+
+let failed = false;
 
 const missing = fileRefs.filter((rel) => !fs.existsSync(path.join(ROOT, rel)));
-
 if (missing.length) {
-  console.error("Missing phase files referenced by orchestrator:");
+  failed = true;
+  console.error("Missing phase files referenced by agents/proveit.md:");
   for (const f of missing) console.error("  -", f);
-  process.exit(1);
 }
+
+const fastCmdPath = path.join(ROOT, "commands/proveit-fast.md");
+const fastCmd = fs.readFileSync(fastCmdPath, "utf8");
+if (!fastCmd.includes("agents/phases/fast-mode.md")) {
+  failed = true;
+  console.error(
+    "commands/proveit-fast.md must reference agents/phases/fast-mode.md"
+  );
+}
+
+if (failed) process.exit(1);
 
 console.log(`OK: ${fileRefs.length} phase/template paths exist`);
 for (const f of fileRefs) {
   const lines = fs.readFileSync(path.join(ROOT, f), "utf8").split("\n").length;
   console.log(`  ${f} (${lines} lines)`);
 }
+console.log("OK: proveit-fast.md → agents/phases/fast-mode.md");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a lightweight CI gate so agent-structure PRs cannot merge with broken phase file references.

### Changes

- **New CI job** `Plugin — agent structure` in `.github/workflows/ci.yml`
  - Runs `node scripts/validate-proveit-agent.mjs` (no npm install — pure Node)
- **Enhanced validator** — dedupes orchestrator refs; asserts `commands/proveit-fast.md` → `agents/phases/fast-mode.md`
- **Local command** — `npm run validate:agent` at repo root
- **Docs** — `AGENTS.md` documents the gate

## Test plan

- [x] `npm run validate:agent` passes locally
- [ ] CI `plugin` job green on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8907759a-6106-4520-bec3-bb88d0f90954?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8907759a-6106-4520-bec3-bb88d0f90954&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

